### PR TITLE
feat: fix ParseChunkSize function and add comprehensive deduplication…

### DIFF
--- a/cmd/dedup.go
+++ b/cmd/dedup.go
@@ -1,0 +1,233 @@
+/*
+Copyright © 2025 SubstantialCattle5, nilaysharan.com
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/deduplication"
+	"github.com/substantialcattle5/sietch/internal/fs"
+	"github.com/substantialcattle5/sietch/util"
+)
+
+// dedupCmd represents the dedup command
+var dedupCmd = &cobra.Command{
+	Use:   "dedup",
+	Short: "Manage deduplication in your Sietch vault",
+	Long: `Manage deduplication settings and operations in your Sietch vault.
+
+This command provides subcommands for:
+- Getting deduplication statistics
+- Running garbage collection
+- Optimizing storage
+
+Example:
+  sietch dedup stats     # Show deduplication statistics
+  sietch dedup gc        # Run garbage collection
+  sietch dedup optimize  # Optimize storage
+`,
+}
+
+// dedupStatsCmd shows deduplication statistics
+var dedupStatsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show deduplication statistics",
+	Long: `Display detailed statistics about deduplication in your vault.
+
+This includes:
+- Total number of chunks
+- Total storage size
+- Space saved through deduplication
+- Number of unreferenced chunks
+
+Example:
+  sietch dedup stats
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultRoot, err := fs.FindVaultRoot()
+		if err != nil {
+			return fmt.Errorf("not inside a vault: %v", err)
+		}
+
+		// Check if vault is initialized
+		if !fs.IsVaultInitialized(vaultRoot) {
+			return fmt.Errorf("vault not initialized, run 'sietch init' first")
+		}
+
+		// Load vault configuration
+		vaultConfig, err := config.LoadVaultConfig(vaultRoot)
+		if err != nil {
+			return fmt.Errorf("failed to load vault configuration: %v", err)
+		}
+
+		// Initialize deduplication manager
+		dedupManager, err := deduplication.NewManager(vaultRoot, vaultConfig.Deduplication)
+		if err != nil {
+			return fmt.Errorf("failed to initialize deduplication manager: %v", err)
+		}
+
+		// Get statistics
+		stats := dedupManager.GetStats()
+
+		// Display statistics
+		fmt.Printf("\nDeduplication Statistics:\n")
+		fmt.Printf("========================\n")
+		fmt.Printf("Deduplication enabled: %v\n", vaultConfig.Deduplication.Enabled)
+		fmt.Printf("Total chunks: %d\n", stats.TotalChunks)
+		fmt.Printf("Total size: %s\n", util.HumanReadableSize(stats.TotalSize))
+		fmt.Printf("Space saved: %s\n", util.HumanReadableSize(stats.SavedSpace))
+		fmt.Printf("Unreferenced chunks: %d\n", stats.UnreferencedChunks)
+
+		if stats.TotalSize > 0 {
+			percentage := float64(stats.SavedSpace) / float64(stats.TotalSize+stats.SavedSpace) * 100
+			fmt.Printf("Deduplication ratio: %.2f%%\n", percentage)
+		}
+
+		if stats.UnreferencedChunks > 0 {
+			fmt.Printf("\n⚠️  You have %d unreferenced chunks. Consider running 'sietch dedup gc' to clean them up.\n", stats.UnreferencedChunks)
+		}
+
+		return nil
+	},
+}
+
+// dedupGcCmd runs garbage collection
+var dedupGcCmd = &cobra.Command{
+	Use:   "gc",
+	Short: "Run garbage collection on unreferenced chunks",
+	Long: `Remove chunks that are no longer referenced by any files.
+
+This command will:
+- Identify chunks that are not referenced by any file manifests
+- Remove these chunks from storage
+- Update the deduplication index
+
+Example:
+  sietch dedup gc
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultRoot, err := fs.FindVaultRoot()
+		if err != nil {
+			return fmt.Errorf("not inside a vault: %v", err)
+		}
+
+		// Check if vault is initialized
+		if !fs.IsVaultInitialized(vaultRoot) {
+			return fmt.Errorf("vault not initialized, run 'sietch init' first")
+		}
+
+		// Load vault configuration
+		vaultConfig, err := config.LoadVaultConfig(vaultRoot)
+		if err != nil {
+			return fmt.Errorf("failed to load vault configuration: %v", err)
+		}
+
+		if !vaultConfig.Deduplication.Enabled {
+			return fmt.Errorf("deduplication is not enabled in this vault")
+		}
+
+		// Initialize deduplication manager
+		dedupManager, err := deduplication.NewManager(vaultRoot, vaultConfig.Deduplication)
+		if err != nil {
+			return fmt.Errorf("failed to initialize deduplication manager: %v", err)
+		}
+
+		fmt.Println("Running garbage collection...")
+
+		// Run garbage collection
+		removedChunks, err := dedupManager.GarbageCollect()
+		if err != nil {
+			return fmt.Errorf("garbage collection failed: %v", err)
+		}
+
+		// Save the updated index
+		if err := dedupManager.Save(); err != nil {
+			return fmt.Errorf("failed to save updated index: %v", err)
+		}
+
+		fmt.Printf("✓ Garbage collection completed\n")
+		fmt.Printf("✓ Removed %d unreferenced chunks\n", removedChunks)
+
+		return nil
+	},
+}
+
+// dedupOptimizeCmd optimizes storage
+var dedupOptimizeCmd = &cobra.Command{
+	Use:   "optimize",
+	Short: "Optimize vault storage",
+	Long: `Perform comprehensive storage optimization.
+
+This command will:
+- Run garbage collection to remove unreferenced chunks
+- Update and optimize the deduplication index
+- Display optimization results
+
+Example:
+  sietch dedup optimize
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vaultRoot, err := fs.FindVaultRoot()
+		if err != nil {
+			return fmt.Errorf("not inside a vault: %v", err)
+		}
+
+		// Check if vault is initialized
+		if !fs.IsVaultInitialized(vaultRoot) {
+			return fmt.Errorf("vault not initialized, run 'sietch init' first")
+		}
+
+		// Load vault configuration
+		vaultConfig, err := config.LoadVaultConfig(vaultRoot)
+		if err != nil {
+			return fmt.Errorf("failed to load vault configuration: %v", err)
+		}
+
+		if !vaultConfig.Deduplication.Enabled {
+			return fmt.Errorf("deduplication is not enabled in this vault")
+		}
+
+		// Initialize deduplication manager
+		dedupManager, err := deduplication.NewManager(vaultRoot, vaultConfig.Deduplication)
+		if err != nil {
+			return fmt.Errorf("failed to initialize deduplication manager: %v", err)
+		}
+
+		fmt.Println("Optimizing vault storage...")
+
+		// Run optimization
+		result, err := dedupManager.OptimizeStorage()
+		if err != nil {
+			return fmt.Errorf("optimization failed: %v", err)
+		}
+
+		// Display results
+		fmt.Printf("\nOptimization Results:\n")
+		fmt.Printf("====================\n")
+		fmt.Printf("✓ Total chunks: %d\n", result.TotalChunks)
+		fmt.Printf("✓ Removed chunks: %d\n", result.RemovedChunks)
+		fmt.Printf("✓ Space saved: %s\n", util.HumanReadableSize(result.SavedSpace))
+		fmt.Printf("✓ Remaining unreferenced chunks: %d\n", result.UnreferencedChunks)
+
+		if result.RemovedChunks > 0 {
+			fmt.Printf("\n✓ Storage optimization completed successfully\n")
+		} else {
+			fmt.Printf("\n✓ Storage is already optimized\n")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dedupCmd)
+
+	// Add subcommands
+	dedupCmd.AddCommand(dedupStatsCmd)
+	dedupCmd.AddCommand(dedupGcCmd)
+	dedupCmd.AddCommand(dedupOptimizeCmd)
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -260,4 +260,4 @@ func init() {
 
 //TODO: Implement parallel chunk retrieval
 //TODO: Implement streaming process
-//TODO: Implemnt atomic operations, rollback on error
+//TODO: Implement atomic operations, rollback on error

--- a/internal/chunk/util.go
+++ b/internal/chunk/util.go
@@ -1,6 +1,7 @@
 package chunk
 
 import (
+	// #nosec G401 - if the user wants to get fcked, let them.
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"

--- a/internal/chunk/util.go
+++ b/internal/chunk/util.go
@@ -1,0 +1,65 @@
+package chunk
+
+import (
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/constants"
+	"github.com/substantialcattle5/sietch/util"
+	"github.com/zeebo/blake3"
+)
+
+// formatChunkInfo formats and prints chunk processing information
+func FormatChunkInfo(chunkCount int, bytesRead int, chunkHash string, vaultConfig config.VaultConfig, chunkDataToProcess []byte, deduplicated bool, encrypted bool) {
+	compressionInfo := ""
+	if vaultConfig.Compression != "none" {
+		compressionInfo = fmt.Sprintf(" (compressed with %s: %s -> %s)",
+			vaultConfig.Compression,
+			util.HumanReadableSize(int64(bytesRead)),
+			util.HumanReadableSize(int64(len(chunkDataToProcess))))
+	}
+
+	dedupInfo := ""
+	if deduplicated {
+		dedupInfo = " [deduplicated]"
+	}
+
+	displayHash := chunkHash
+	if encrypted && len(chunkHash) > HashDisplayLength {
+		displayHash = chunkHash[:HashDisplayLength]
+	}
+
+	encryptionInfo := ""
+	if encrypted {
+		encryptionInfo = " (encrypted)"
+	}
+
+	fmt.Printf("Chunk %d: %s bytes, hash: %s%s%s%s\n",
+		chunkCount,
+		util.HumanReadableSize(int64(bytesRead)),
+		displayHash,
+		encryptionInfo,
+		compressionInfo,
+		dedupInfo)
+}
+
+// createHasher creates a hasher based on the configured hash algorithm
+func CreateHasher(algorithm string) (hash.Hash, error) {
+	switch algorithm {
+	case constants.HashAlgorithmSHA256, "": // Default to SHA-256 if empty
+		return sha256.New(), nil
+	case constants.HashAlgorithmSHA512:
+		return sha512.New(), nil
+	case constants.HashAlgorithmSHA1:
+		// #nosec G401
+		return sha1.New(), nil
+	case constants.HashAlgorithmBLAKE3:
+		return blake3.New(), nil
+	default:
+		return nil, fmt.Errorf("unsupported hash algorithm: %s", algorithm)
+	}
+}

--- a/internal/chunk/util.go
+++ b/internal/chunk/util.go
@@ -1,8 +1,7 @@
 package chunk
 
 import (
-	// #nosec G401 - if the user wants to get fcked, let them.
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G401 - if the user wants to get fcked, let them.
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"

--- a/internal/deduplication/deduplicationTypes.go
+++ b/internal/deduplication/deduplicationTypes.go
@@ -1,0 +1,35 @@
+package deduplication
+
+import (
+	"sync"
+	"time"
+)
+
+// DeduplicationStats contains statistics about deduplication
+type DeduplicationStats struct {
+	TotalChunks        int   `json:"total_chunks"`
+	TotalSize          int64 `json:"total_size"`
+	UnreferencedChunks int   `json:"unreferenced_chunks"`
+	SavedSpace         int64 `json:"saved_space"`
+}
+
+// ChunkIndexEntry represents metadata about a chunk in the deduplication index
+type ChunkIndexEntry struct {
+	Hash           string    `json:"hash"`
+	Size           int64     `json:"size"`
+	RefCount       int       `json:"ref_count"`
+	StorageHash    string    `json:"storage_hash"` // Hash used for storage (encrypted hash if applicable)
+	FirstSeen      time.Time `json:"first_seen"`
+	LastReferenced time.Time `json:"last_referenced"`
+	Compressed     bool      `json:"compressed"`
+	Encrypted      bool      `json:"encrypted"`
+}
+
+// DeduplicationIndex manages the chunk deduplication index
+type DeduplicationIndex struct {
+	vaultRoot string
+	indexPath string
+	entries   map[string]*ChunkIndexEntry
+	mutex     sync.RWMutex
+	dirty     bool // Track if index needs to be saved
+}

--- a/internal/deduplication/index.go
+++ b/internal/deduplication/index.go
@@ -1,0 +1,223 @@
+package deduplication
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/constants"
+	"github.com/substantialcattle5/sietch/internal/fs"
+)
+
+// NewDeduplicationIndex creates a new deduplication index
+func NewDeduplicationIndex(vaultRoot string) (*DeduplicationIndex, error) {
+	indexPath := filepath.Join(vaultRoot, ".sietch", "dedup_index.json")
+
+	idx := &DeduplicationIndex{
+		vaultRoot: vaultRoot,
+		indexPath: indexPath,
+		entries:   make(map[string]*ChunkIndexEntry),
+		dirty:     false,
+	}
+
+	// Load existing index if it exists
+	if err := idx.Load(); err != nil {
+		// If file doesn't exist, that's okay - we'll create it when we save
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to load deduplication index: %w", err)
+		}
+	}
+
+	return idx, nil
+}
+
+// Load loads the deduplication index from disk
+func (idx *DeduplicationIndex) Load() error {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	data, err := os.ReadFile(idx.indexPath)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, &idx.entries)
+}
+
+// Save saves the deduplication index to disk
+func (idx *DeduplicationIndex) Save() error {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if !idx.dirty {
+		return nil // No changes to save
+	}
+
+	// Ensure the directory exists
+	dir := filepath.Dir(idx.indexPath)
+	if err := os.MkdirAll(dir, constants.StandardDirPerms); err != nil {
+		return fmt.Errorf("failed to create index directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(idx.entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal index: %w", err)
+	}
+
+	if err := os.WriteFile(idx.indexPath, data, constants.StandardFilePerms); err != nil {
+		return fmt.Errorf("failed to write index file: %w", err)
+	}
+
+	idx.dirty = false
+	return nil
+}
+
+// HasChunk checks if a chunk exists in the index
+func (idx *DeduplicationIndex) HasChunk(hash string) bool {
+	idx.mutex.RLock()
+	defer idx.mutex.RUnlock()
+
+	_, exists := idx.entries[hash]
+	return exists
+}
+
+// GetChunk retrieves chunk metadata from the index
+func (idx *DeduplicationIndex) GetChunk(hash string) (*ChunkIndexEntry, bool) {
+	idx.mutex.RLock()
+	defer idx.mutex.RUnlock()
+
+	entry, exists := idx.entries[hash]
+	if !exists {
+		return nil, false
+	}
+
+	// Create a copy to avoid race conditions
+	entryCopy := *entry
+	return &entryCopy, true
+}
+
+// AddChunk adds a new chunk to the index or increments reference count if it exists
+func (idx *DeduplicationIndex) AddChunk(chunkRef config.ChunkRef, storageHash string) (*ChunkIndexEntry, bool) {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	now := time.Now()
+
+	// Check if chunk already exists
+	if entry, exists := idx.entries[chunkRef.Hash]; exists {
+		// Increment reference count
+		entry.RefCount++
+		entry.LastReferenced = now
+		idx.dirty = true
+
+		// Create a copy to return
+		entryCopy := *entry
+		return &entryCopy, true // true indicates deduplication occurred
+	}
+
+	// Create new entry
+	entry := &ChunkIndexEntry{
+		Hash:           chunkRef.Hash,
+		Size:           chunkRef.Size,
+		RefCount:       1,
+		StorageHash:    storageHash,
+		FirstSeen:      now,
+		LastReferenced: now,
+		Compressed:     chunkRef.Compressed,
+		Encrypted:      chunkRef.EncryptedHash != "",
+	}
+
+	idx.entries[chunkRef.Hash] = entry
+	idx.dirty = true
+
+	// Create a copy to return
+	entryCopy := *entry
+	return &entryCopy, false // false indicates new chunk
+}
+
+// RemoveChunk decrements the reference count of a chunk and removes it if ref count reaches 0
+func (idx *DeduplicationIndex) RemoveChunk(hash string) error {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	entry, exists := idx.entries[hash]
+	if !exists {
+		return fmt.Errorf("chunk not found in index: %s", hash)
+	}
+
+	entry.RefCount--
+	if entry.RefCount <= 0 {
+		delete(idx.entries, hash)
+		idx.dirty = true
+
+		// Also remove the actual chunk file
+		return idx.removeChunkFile(entry.StorageHash)
+	}
+
+	idx.dirty = true
+	return nil
+}
+
+// removeChunkFile removes the physical chunk file from storage
+func (idx *DeduplicationIndex) removeChunkFile(storageHash string) error {
+	chunkPath := filepath.Join(fs.GetChunkDirectory(idx.vaultRoot), storageHash)
+	if err := os.Remove(chunkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove chunk file %s: %w", storageHash, err)
+	}
+	return nil
+}
+
+// GetStats returns statistics about the deduplication index
+func (idx *DeduplicationIndex) GetStats() DeduplicationStats {
+	idx.mutex.RLock()
+	defer idx.mutex.RUnlock()
+
+	stats := DeduplicationStats{
+		TotalChunks:        len(idx.entries),
+		TotalSize:          0,
+		UnreferencedChunks: 0,
+		SavedSpace:         0,
+	}
+
+	for _, entry := range idx.entries {
+		stats.TotalSize += entry.Size
+		if entry.RefCount == 0 {
+			stats.UnreferencedChunks++
+		}
+		if entry.RefCount > 1 {
+			stats.SavedSpace += entry.Size * int64(entry.RefCount-1)
+		}
+	}
+
+	return stats
+}
+
+// GarbageCollect removes unreferenced chunks
+func (idx *DeduplicationIndex) GarbageCollect() (int, error) {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	var toRemove []string
+	for hash, entry := range idx.entries {
+		if entry.RefCount <= 0 {
+			toRemove = append(toRemove, hash)
+		}
+	}
+
+	for _, hash := range toRemove {
+		entry := idx.entries[hash]
+		if err := idx.removeChunkFile(entry.StorageHash); err != nil {
+			fmt.Printf("Warning: failed to remove chunk file for %s: %v\n", hash, err)
+		}
+		delete(idx.entries, hash)
+	}
+
+	if len(toRemove) > 0 {
+		idx.dirty = true
+	}
+
+	return len(toRemove), nil
+}

--- a/internal/deduplication/manager.go
+++ b/internal/deduplication/manager.go
@@ -61,7 +61,9 @@ func (m *Manager) ProcessChunk(chunkRef config.ChunkRef, chunkData []byte, stora
 		// New chunk, store it
 		if err := m.storeChunk(storageHash, chunkData); err != nil {
 			// Remove from index if storage failed
-			m.index.RemoveChunk(chunkRef.Hash)
+			if m.index.RemoveChunk(chunkRef.Hash) != nil {
+				fmt.Printf("Warning: failed to remove chunk %s from index: %v\n", chunkRef.Hash, err)
+			}
 			return chunkRef, false, err
 		}
 		chunkRef.Deduplicated = false

--- a/internal/deduplication/manager.go
+++ b/internal/deduplication/manager.go
@@ -1,0 +1,175 @@
+package deduplication
+
+import (
+	"fmt"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/fs"
+	"github.com/substantialcattle5/sietch/util"
+)
+
+// Manager handles deduplication operations for a vault
+type Manager struct {
+	vaultRoot string
+	config    config.DeduplicationConfig
+	index     *DeduplicationIndex
+}
+
+// NewManager creates a new deduplication manager
+func NewManager(vaultRoot string, dedupConfig config.DeduplicationConfig) (*Manager, error) {
+	index, err := NewDeduplicationIndex(vaultRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create deduplication index: %w", err)
+	}
+
+	return &Manager{
+		vaultRoot: vaultRoot,
+		config:    dedupConfig,
+		index:     index,
+	}, nil
+}
+
+// ProcessChunk processes a chunk for deduplication
+// Returns: (chunkRef, deduplicated, error)
+func (m *Manager) ProcessChunk(chunkRef config.ChunkRef, chunkData []byte, storageHash string) (config.ChunkRef, bool, error) {
+	if !m.config.Enabled {
+		// Deduplication disabled, store chunk normally
+		if err := m.storeChunk(storageHash, chunkData); err != nil {
+			return chunkRef, false, err
+		}
+		return chunkRef, false, nil
+	}
+
+	// Check if we should deduplicate this chunk based on size constraints
+	if !m.shouldDeduplicateChunk(chunkRef.Size) {
+		// Store chunk normally without deduplication
+		if err := m.storeChunk(storageHash, chunkData); err != nil {
+			return chunkRef, false, err
+		}
+		return chunkRef, false, nil
+	}
+
+	// Check if chunk already exists in index
+	entry, deduplicated := m.index.AddChunk(chunkRef, storageHash)
+
+	if deduplicated {
+		// Chunk already exists, no need to store it again
+		chunkRef.Deduplicated = true
+		fmt.Printf("  └─ Deduplicated chunk %s (ref count: %d)\n",
+			chunkRef.Hash[:12], entry.RefCount)
+	} else {
+		// New chunk, store it
+		if err := m.storeChunk(storageHash, chunkData); err != nil {
+			// Remove from index if storage failed
+			m.index.RemoveChunk(chunkRef.Hash)
+			return chunkRef, false, err
+		}
+		chunkRef.Deduplicated = false
+	}
+
+	return chunkRef, deduplicated, nil
+}
+
+// shouldDeduplicateChunk checks if a chunk should be deduplicated based on configuration
+func (m *Manager) shouldDeduplicateChunk(chunkSize int64) bool {
+	if !m.config.Enabled {
+		return false
+	}
+
+	minSize, err := util.ParseChunkSize(m.config.MinChunkSize)
+	if err != nil {
+		minSize = 1024 // Default to 1KB
+	}
+
+	maxSize, err := util.ParseChunkSize(m.config.MaxChunkSize)
+	if err != nil {
+		maxSize = 64 * 1024 * 1024 // Default to 64MB
+	}
+
+	return chunkSize >= minSize && chunkSize <= maxSize
+}
+
+// storeChunk stores a chunk to the filesystem
+func (m *Manager) storeChunk(storageHash string, chunkData []byte) error {
+	return fs.StoreChunk(m.vaultRoot, storageHash, chunkData)
+}
+
+// GetStats returns deduplication statistics
+func (m *Manager) GetStats() DeduplicationStats {
+	return m.index.GetStats()
+}
+
+// GarbageCollect removes unreferenced chunks
+func (m *Manager) GarbageCollect() (int, error) {
+	return m.index.GarbageCollect()
+}
+
+// Save saves the deduplication index
+func (m *Manager) Save() error {
+	return m.index.Save()
+}
+
+// RemoveFileChunks removes all chunks associated with a file
+func (m *Manager) RemoveFileChunks(chunks []config.ChunkRef) error {
+	for _, chunk := range chunks {
+		if err := m.index.RemoveChunk(chunk.Hash); err != nil {
+			return fmt.Errorf("failed to remove chunk %s: %w", chunk.Hash, err)
+		}
+	}
+	return nil
+}
+
+// OptimizeStorage performs optimization operations
+func (m *Manager) OptimizeStorage() (*OptimizationResult, error) {
+	stats := m.GetStats()
+
+	// Perform garbage collection
+	removedChunks, err := m.GarbageCollect()
+	if err != nil {
+		return nil, fmt.Errorf("garbage collection failed: %w", err)
+	}
+
+	// Save index after optimization
+	if err := m.Save(); err != nil {
+		return nil, fmt.Errorf("failed to save index after optimization: %w", err)
+	}
+
+	return &OptimizationResult{
+		RemovedChunks:      removedChunks,
+		TotalChunks:        stats.TotalChunks,
+		SavedSpace:         stats.SavedSpace,
+		UnreferencedChunks: stats.UnreferencedChunks,
+	}, nil
+}
+
+// OptimizationResult contains the results of storage optimization
+type OptimizationResult struct {
+	RemovedChunks      int   `json:"removed_chunks"`
+	TotalChunks        int   `json:"total_chunks"`
+	SavedSpace         int64 `json:"saved_space"`
+	UnreferencedChunks int   `json:"unreferenced_chunks"`
+}
+
+// ChunkExists checks if a chunk exists (for compatibility with existing code)
+func (m *Manager) ChunkExists(hash string) bool {
+	if !m.config.Enabled {
+		return fs.ChunkExists(m.vaultRoot, hash)
+	}
+	return m.index.HasChunk(hash)
+}
+
+// GetChunk retrieves a chunk (for compatibility with existing code)
+func (m *Manager) GetChunk(hash string) ([]byte, error) {
+	if !m.config.Enabled {
+		return fs.GetChunk(m.vaultRoot, hash)
+	}
+
+	// Get chunk metadata from index
+	entry, exists := m.index.GetChunk(hash)
+	if !exists {
+		return nil, fmt.Errorf("chunk not found: %s", hash)
+	}
+
+	// Retrieve chunk using storage hash
+	return fs.GetChunk(m.vaultRoot, entry.StorageHash)
+}

--- a/internal/deduplication/manager_test.go
+++ b/internal/deduplication/manager_test.go
@@ -1,0 +1,243 @@
+package deduplication
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/testutil"
+)
+
+func TestDeduplicationManager(t *testing.T) {
+	// Create a temporary vault directory
+	vaultPath := testutil.TempDir(t, "dedup-test-vault")
+
+	// Create vault structure
+	err := os.MkdirAll(filepath.Join(vaultPath, ".sietch", "chunks"), 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create vault structure: %v", err)
+	}
+
+	// Create deduplication config
+	dedupConfig := config.DeduplicationConfig{
+		Enabled:        true,
+		Strategy:       "content",
+		MinChunkSize:   "0", // 0MB minimum = 0 bytes minimum for testing
+		MaxChunkSize:   "64",
+		GCThreshold:    100,
+		IndexEnabled:   true,
+		CrossFileDedup: true,
+	}
+
+	// Create manager
+	manager, err := NewManager(vaultPath, dedupConfig)
+	if err != nil {
+		t.Fatalf("Failed to create deduplication manager: %v", err)
+	}
+
+	// Test data
+	testData := []byte("This is test chunk data for deduplication testing")
+	chunkHash := "abc123def456"
+	storageHash := "stored_abc123def456"
+
+	// Create chunk reference
+	chunkRef := config.ChunkRef{
+		Hash:         chunkHash,
+		Size:         int64(len(testData)),
+		Index:        0,
+		Compressed:   false,
+		Deduplicated: false,
+	}
+
+	t.Run("ProcessNewChunk", func(t *testing.T) {
+		// Process new chunk
+		updatedRef, deduplicated, err := manager.ProcessChunk(chunkRef, testData, storageHash)
+		if err != nil {
+			t.Fatalf("Failed to process new chunk: %v", err)
+		}
+
+		if deduplicated {
+			t.Error("New chunk should not be marked as deduplicated")
+		}
+
+		if updatedRef.Deduplicated {
+			t.Error("New chunk reference should not be marked as deduplicated")
+		}
+
+		// Debug: Check if chunk exists in index
+		if !manager.index.HasChunk(chunkHash) {
+			t.Error("Chunk should exist in index after processing")
+		}
+
+		// Verify chunk exists in storage
+		if !manager.ChunkExists(chunkHash) {
+			t.Error("Chunk should exist after processing")
+		}
+	})
+
+	t.Run("ProcessDuplicateChunk", func(t *testing.T) {
+		// Process the same chunk again
+		updatedRef, deduplicated, err := manager.ProcessChunk(chunkRef, testData, storageHash)
+		if err != nil {
+			t.Fatalf("Failed to process duplicate chunk: %v", err)
+		}
+
+		if !deduplicated {
+			t.Error("Duplicate chunk should be marked as deduplicated")
+		}
+
+		if !updatedRef.Deduplicated {
+			t.Error("Duplicate chunk reference should be marked as deduplicated")
+		}
+
+		// Verify chunk still exists
+		if !manager.ChunkExists(chunkHash) {
+			t.Error("Chunk should still exist after deduplication")
+		}
+	})
+
+	t.Run("GetStats", func(t *testing.T) {
+		stats := manager.GetStats()
+
+		if stats.TotalChunks != 1 {
+			t.Errorf("Expected 1 total chunk, got %d", stats.TotalChunks)
+		}
+
+		if stats.TotalSize != int64(len(testData)) {
+			t.Errorf("Expected total size %d, got %d", len(testData), stats.TotalSize)
+		}
+
+		if stats.SavedSpace != int64(len(testData)) {
+			t.Errorf("Expected saved space %d, got %d", len(testData), stats.SavedSpace)
+		}
+	})
+
+	t.Run("SaveAndLoad", func(t *testing.T) {
+		// Save the index
+		err := manager.Save()
+		if err != nil {
+			t.Fatalf("Failed to save index: %v", err)
+		}
+
+		// Create a new manager to test loading
+		newManager, err := NewManager(vaultPath, dedupConfig)
+		if err != nil {
+			t.Fatalf("Failed to create new manager: %v", err)
+		}
+
+		// Verify the chunk exists in the new manager
+		if !newManager.ChunkExists(chunkHash) {
+			t.Error("Chunk should exist in loaded index")
+		}
+
+		// Verify stats are preserved
+		stats := newManager.GetStats()
+		if stats.TotalChunks != 1 {
+			t.Errorf("Expected 1 total chunk after reload, got %d", stats.TotalChunks)
+		}
+	})
+}
+
+func TestDeduplicationIndex(t *testing.T) {
+	// Create a temporary vault directory
+	vaultPath := testutil.TempDir(t, "dedup-index-test")
+
+	// Create index
+	index, err := NewDeduplicationIndex(vaultPath)
+	if err != nil {
+		t.Fatalf("Failed to create deduplication index: %v", err)
+	}
+
+	// Test data
+	chunkRef := config.ChunkRef{
+		Hash:       "test_hash_123",
+		Size:       1024,
+		Index:      0,
+		Compressed: false,
+	}
+	storageHash := "storage_test_hash_123"
+
+	t.Run("AddNewChunk", func(t *testing.T) {
+		entry, deduplicated := index.AddChunk(chunkRef, storageHash)
+
+		if deduplicated {
+			t.Error("New chunk should not be marked as deduplicated")
+		}
+
+		if entry.RefCount != 1 {
+			t.Errorf("Expected ref count 1, got %d", entry.RefCount)
+		}
+
+		if entry.Hash != chunkRef.Hash {
+			t.Errorf("Expected hash %s, got %s", chunkRef.Hash, entry.Hash)
+		}
+	})
+
+	t.Run("AddDuplicateChunk", func(t *testing.T) {
+		entry, deduplicated := index.AddChunk(chunkRef, storageHash)
+
+		if !deduplicated {
+			t.Error("Duplicate chunk should be marked as deduplicated")
+		}
+
+		if entry.RefCount != 2 {
+			t.Errorf("Expected ref count 2, got %d", entry.RefCount)
+		}
+	})
+
+	t.Run("HasChunk", func(t *testing.T) {
+		if !index.HasChunk(chunkRef.Hash) {
+			t.Error("Index should contain the chunk")
+		}
+
+		if index.HasChunk("nonexistent_hash") {
+			t.Error("Index should not contain nonexistent chunk")
+		}
+	})
+
+	t.Run("GetChunk", func(t *testing.T) {
+		entry, exists := index.GetChunk(chunkRef.Hash)
+
+		if !exists {
+			t.Error("Chunk should exist in index")
+		}
+
+		if entry.Hash != chunkRef.Hash {
+			t.Errorf("Expected hash %s, got %s", chunkRef.Hash, entry.Hash)
+		}
+
+		if entry.RefCount != 2 {
+			t.Errorf("Expected ref count 2, got %d", entry.RefCount)
+		}
+	})
+
+	t.Run("RemoveChunk", func(t *testing.T) {
+		// Remove chunk once (should decrement ref count)
+		err := index.RemoveChunk(chunkRef.Hash)
+		if err != nil {
+			t.Fatalf("Failed to remove chunk: %v", err)
+		}
+
+		entry, exists := index.GetChunk(chunkRef.Hash)
+		if !exists {
+			t.Error("Chunk should still exist after single removal")
+		}
+
+		if entry.RefCount != 1 {
+			t.Errorf("Expected ref count 1 after removal, got %d", entry.RefCount)
+		}
+	})
+
+	t.Run("GetStats", func(t *testing.T) {
+		stats := index.GetStats()
+
+		if stats.TotalChunks != 1 {
+			t.Errorf("Expected 1 total chunk, got %d", stats.TotalChunks)
+		}
+
+		if stats.TotalSize != chunkRef.Size {
+			t.Errorf("Expected total size %d, got %d", chunkRef.Size, stats.TotalSize)
+		}
+	})
+}

--- a/util/ParseChunkSize.go
+++ b/util/ParseChunkSize.go
@@ -1,13 +1,56 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
 
 func ParseChunkSize(chunkSize string) (int64, error) {
-	var size int64
-	_, err := fmt.Sscanf(chunkSize, "%d", &size)
-	if err != nil {
+	if chunkSize == "" {
+		return 0, fmt.Errorf("size cannot be empty")
+	}
+
+	// Regular expression to parse size with optional unit (including negative numbers)
+	re := regexp.MustCompile(`^(-?\d+(?:\.\d+)?)\s*([a-zA-Z]*)$`)
+	matches := re.FindStringSubmatch(strings.TrimSpace(chunkSize))
+
+	if len(matches) != 3 {
 		return 0, fmt.Errorf("invalid size format: %s", chunkSize)
 	}
-	// we're not verifying the size here, because we're not sure if the user is using the correct units
-	return size * 1024 * 1024, nil // Convert to bytes
+
+	// Parse the numeric part
+	sizeFloat, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid numeric value: %s", matches[1])
+	}
+
+	// Parse the unit part (case-insensitive)
+	unit := strings.ToUpper(strings.TrimSpace(matches[2]))
+
+	var multiplier int64
+	switch unit {
+	case "", "B", "BYTES":
+		multiplier = 1
+	case "K", "KB", "KILOBYTES":
+		multiplier = 1024
+	case "M", "MB", "MEGABYTES":
+		multiplier = 1024 * 1024
+	case "G", "GB", "GIGABYTES":
+		multiplier = 1024 * 1024 * 1024
+	case "T", "TB", "TERABYTES":
+		multiplier = 1024 * 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("unsupported unit: %s", unit)
+	}
+
+	// Calculate final size in bytes
+	result := int64(sizeFloat * float64(multiplier))
+
+	if result < 0 {
+		return 0, fmt.Errorf("size cannot be negative")
+	}
+
+	return result, nil
 }


### PR DESCRIPTION

- Fix ParseChunkSize to properly handle units (KB, MB, GB, TB)
- Add deduplication configuration to vault initialization
- Update all tests to match new ParseChunkSize behavior
- Add comprehensive test coverage for size units and edge cases
- Ensure deduplication works correctly with proper size parsing

Fixes deduplication functionality that was broken due to incorrect size parsing