### PR TITLE
Fix sneakernet chunk transfer for encrypted vaults

### DIFF
--- a/internal/sneakernet/transfer.go
+++ b/internal/sneakernet/transfer.go
@@ -185,29 +185,87 @@ func (st *SneakTransfer) Execute() (*TransferResult, error) {
 
 // transferChunkWithManagers copies a chunk from source to destination using provided managers
 func (st *SneakTransfer) transferChunkWithManagers(chunkHash string, sourceManager, destManager *config.Manager) error {
-	// Check if chunk already exists in destination
+	// For encrypted vaults, chunks are stored with encrypted_hash as filename
+	// but we receive the plain hash. We need to try both plain and encrypted hash.
+
+	// First, try to use the plain hash (works for unencrypted vaults and backwards compatibility)
 	exists, err := destManager.ChunkExists(chunkHash)
 	if err != nil {
 		return fmt.Errorf("failed to check chunk existence: %v", err)
+	}
+
+	storageHash := chunkHash
+	if exists {
+		// Chunk exists with plain hash, use it
+	} else {
+		// Chunk doesn't exist with plain hash. For encrypted vaults, try to find it with encrypted hash.
+		// We need to check if this is an encrypted vault and find the encrypted hash.
+		if encryptedHash := st.findEncryptedHashForChunk(chunkHash, sourceManager); encryptedHash != "" {
+			storageHash = encryptedHash
+
+			// Check if chunk exists with encrypted hash
+			exists, err = destManager.ChunkExists(encryptedHash)
+			if err != nil {
+				return fmt.Errorf("failed to check chunk existence with encrypted hash: %v", err)
+			}
+		}
 	}
 
 	if exists {
 		return nil // Already exists, skip
 	}
 
-	// Read chunk from source
-	sourceChunkData, err := sourceManager.GetChunk(chunkHash)
+	// Read chunk from source using the appropriate hash
+	sourceChunkData, err := sourceManager.GetChunk(storageHash)
 	if err != nil {
 		return fmt.Errorf("failed to read source chunk: %v", err)
 	}
 
-	// Store chunk in destination
-	err = destManager.StoreChunk(chunkHash, sourceChunkData)
+	// Store chunk in destination using the appropriate hash
+	err = destManager.StoreChunk(storageHash, sourceChunkData)
 	if err != nil {
 		return fmt.Errorf("failed to store chunk: %v", err)
 	}
 
 	return nil
+}
+
+// findEncryptedHashForChunk finds the encrypted hash for a chunk given its plain hash
+func (st *SneakTransfer) findEncryptedHashForChunk(plainHash string, sourceManager *config.Manager) string {
+	// Get the source vault configuration to check if it's encrypted
+	vaultConfig, err := sourceManager.GetConfig()
+	if err != nil {
+		if st.Verbose {
+			fmt.Printf("Warning: Failed to get vault config to check encryption: %v\n", err)
+		}
+		return ""
+	}
+
+	// If vault is not encrypted, chunks are stored with plain hash
+	if vaultConfig.Encryption.Type == "" || vaultConfig.Encryption.Type == "none" {
+		return ""
+	}
+
+	// For encrypted vaults, we need to find the chunk metadata
+	// Get the manifest to find chunk references
+	manifest, err := sourceManager.GetManifest()
+	if err != nil {
+		if st.Verbose {
+			fmt.Printf("Warning: Failed to get manifest to find encrypted hash: %v\n", err)
+		}
+		return ""
+	}
+
+	// Search through all files and chunks to find the matching plain hash
+	for _, file := range manifest.Files {
+		for _, chunk := range file.Chunks {
+			if chunk.Hash == plainHash && chunk.EncryptedHash != "" {
+				return chunk.EncryptedHash
+			}
+		}
+	}
+
+	return ""
 }
 
 // transferManifestsWithAnalysis handles manifest transfer for new files and conflicts


### PR DESCRIPTION
**Description**
This PR addresses a bug in the sneakernet transfer functionality where chunks in encrypted vaults were failing to transfer due to incorrect hash usage. The issue occurred because encrypted vaults store chunks using encrypted hashes as filenames, but the transfer logic was only using plain hashes.

**Changes made**
- Modified `transferChunkWithManagers` to check for chunk existence using both plain and encrypted hashes
- Added `findEncryptedHashForChunk` helper function to locate the encrypted hash for a given plain hash by examining the vault manifest
- Updated chunk read and store operations to use the appropriate hash (plain for unencrypted vaults, encrypted for encrypted vaults)

**Referenced Issue:** #43 