### PR TITLE
Enable conflict detection in sneakernet transfers

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,6 +209,15 @@ Examples:
 			sizeInBytes := fileInfo.Size()
 			sizeReadable := util.HumanReadableSize(sizeInBytes)
 
+			// Compute content hash for the entire file
+			contentHash, err := computeContentHash(actualSourcePath, vaultConfig.Chunking.HashAlgorithm)
+			if err != nil {
+				errorMsg := fmt.Sprintf("✗ %s: %v", filepath.Base(pair.Source), err)
+				fmt.Println(errorMsg)
+				failedFiles = append(failedFiles, errorMsg)
+				continue
+			}
+
 			// Display file metadata for confirmation (only for single files or when verbose)
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			if len(filePairs) == 1 || verbose {
@@ -249,6 +259,7 @@ Examples:
 				ModTime:     fileInfo.ModTime().Format(time.RFC3339),
 				Chunks:      chunkRefs,
 				Destination: destDir,
+				ContentHash: contentHash,
 				AddedAt:     time.Now().UTC(),
 				Tags:        tags, // Include tags in the manifest
 			}
@@ -504,6 +515,27 @@ func expandDirectories(pairs []FilePair, recursive bool, includeHidden bool) ([]
 	}
 
 	return expandedPairs, nil
+}
+
+// computeContentHash computes the hash of the entire file content
+func computeContentHash(filePath, hashAlgorithm string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file for hashing: %v", err)
+	}
+	defer file.Close()
+
+	hasher, err := chunk.CreateHasher(hashAlgorithm)
+	if err != nil {
+		return "", fmt.Errorf("failed to create hasher: %v", err)
+	}
+
+	_, err = io.Copy(hasher, file)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash file content: %v", err)
+	}
+
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
 }
 
 func init() {


### PR DESCRIPTION
**Description**
Sneakernet conflict detection was failing because `ContentHash` was never populated in `FileManifest` structures. This caused all conflict comparisons to return false, preventing detection of files with the same path but different content.

**Referenced Issue:** #46 