### PR TITLE
fix: store and use compression type in ChunkRef to prevent magic numb…

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -223,7 +223,14 @@ Example:
 
 			// Decompress the chunk if it was compressed
 			if chunkRef.Compressed {
-				decompressedData, err := compression.DecompressData(chunkData, vaultConfig.Compression)
+				// Use the compression type stored in the chunk ref, not the current vault config
+				// This handles cases where the vault compression setting changed after the file was added
+				compressionType := chunkRef.CompressionType
+				if compressionType == "" {
+					// Fallback to vault config for backwards compatibility with old manifests
+					compressionType = vaultConfig.Compression
+				}
+				decompressedData, err := compression.DecompressData(chunkData, compressionType)
 				if err != nil {
 					return fmt.Errorf("failed to decompress chunk %s: %v", chunkHash, err)
 				}

--- a/internal/chunk/chunkFile.go
+++ b/internal/chunk/chunkFile.go
@@ -111,10 +111,11 @@ func processFileChunks(file *os.File, chunkSize int64, vaultConfig config.VaultC
 
 		// Create chunk reference
 		chunkRef := config.ChunkRef{
-			Hash:       chunkHash,
-			Size:       int64(bytesRead),
-			Index:      chunkCount - 1, // Convert 1-based chunkCount to 0-based index
-			Compressed: vaultConfig.Compression != "none",
+			Hash:            chunkHash,
+			Size:            int64(bytesRead),
+			Index:           chunkCount - 1, // Convert 1-based chunkCount to 0-based index
+			Compressed:      vaultConfig.Compression != "none",
+			CompressionType: vaultConfig.Compression,
 		}
 
 		// Use compressed data for further processing

--- a/internal/config/vault.go
+++ b/internal/config/vault.go
@@ -146,15 +146,16 @@ type FileEncryptionInfo struct {
 
 // ChunkRef references a chunk in the vault
 type ChunkRef struct {
-	Hash          string `yaml:"hash"`                     // Hash of chunk content (pre-encryption)
-	EncryptedHash string `yaml:"encrypted_hash,omitempty"` // Hash of encrypted chunk (filename in storage)
-	Size          int64  `yaml:"size"`                     // Size of plaintext chunk
-	EncryptedSize int64  `yaml:"encrypted_size,omitempty"` // Size after encryption
-	Index         int    `yaml:"index"`                    // Position in the file
-	Deduplicated  bool   `yaml:"deduplicated,omitempty"`   // Whether this chunk was deduplicated
-	Compressed    bool   `yaml:"compressed,omitempty"`     // Whether this chunk was compressed
-	IV            string `yaml:"iv,omitempty"`             // Per-chunk IV if used
-	Integrity     string `yaml:"integrity,omitempty"`      // Integrity check value (e.g., HMAC)
+	Hash            string `yaml:"hash"`                       // Hash of chunk content (pre-encryption)
+	EncryptedHash   string `yaml:"encrypted_hash,omitempty"`   // Hash of encrypted chunk (filename in storage)
+	Size            int64  `yaml:"size"`                       // Size of plaintext chunk
+	EncryptedSize   int64  `yaml:"encrypted_size,omitempty"`   // Size after encryption
+	Index           int    `yaml:"index"`                      // Position in the file
+	Deduplicated    bool   `yaml:"deduplicated,omitempty"`     // Whether this chunk was deduplicated
+	Compressed      bool   `yaml:"compressed,omitempty"`       // Whether this chunk was compressed
+	CompressionType string `yaml:"compression_type,omitempty"` // Compression algorithm used (e.g., "gzip", "zstd", "none")
+	IV              string `yaml:"iv,omitempty"`               // Per-chunk IV if used
+	Integrity       string `yaml:"integrity,omitempty"`        // Integrity check value (e.g., HMAC)
 }
 
 // BuildVaultConfig creates a complete vault configuration with all necessary fields


### PR DESCRIPTION
…er mismatch

- Add CompressionType field to ChunkRef struct
- Store actual compression algorithm when creating chunks
- Use stored compression type during decompression instead of vault config
- Add fallback to vault config for backwards compatibility

Fixes #33