### PR TITLE
Fix syncing: save file manifests after chunk download

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -113,10 +113,12 @@ func (m *Manager) RebuildReferences() error {
 	// 3. Update any inconsistent references
 	return nil
 }
+
 // VaultRoot returns the root directory of the vault.
 func (m *Manager) VaultRoot() string {
-    return m.vaultRoot
+	return m.vaultRoot
 }
+
 // Helper function to load a file manifest
 func loadFileManifest(path string) (*FileManifest, error) {
 	// Read manifest file

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -113,7 +113,10 @@ func (m *Manager) RebuildReferences() error {
 	// 3. Update any inconsistent references
 	return nil
 }
-
+// VaultRoot returns the root directory of the vault.
+func (m *Manager) VaultRoot() string {
+    return m.vaultRoot
+}
 // Helper function to load a file manifest
 func loadFileManifest(path string) (*FileManifest, error) {
 	// Read manifest file

--- a/internal/p2p/sync.go
+++ b/internal/p2p/sync.go
@@ -21,6 +21,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/manifest" //golangci-lint error
 )
 
 const (
@@ -836,7 +837,6 @@ func (s *SyncService) AddTrustedPeer(ctx context.Context, peerID peer.ID) error 
 	return nil
 }
 
-
 // SyncWithPeer performs a sync operation with a specific peer
 func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncResult, error) {
 	// Create a context with timeout for the entire operation
@@ -929,18 +929,18 @@ func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncRe
 				break
 			}
 		}
-		
+
 		if !exists {
 			// Create a copy of the file manifest to avoid pointer issues
 			fileManifest := remoteFile
-			
+
 			err := manifest.StoreFileManifest(
 				s.vaultMgr.VaultRoot(),
 				fileManifest.FilePath,
 				&fileManifest,
 			)
 			if err != nil {
-				return nil, fmt.Errorf("failed to save manifest for %s: %v", 
+				return nil, fmt.Errorf("failed to save manifest for %s: %v",
 					fileManifest.FilePath, err)
 			}
 			fmt.Printf("Saved manifest for: %s\n", fileManifest.FilePath)

--- a/internal/p2p/sync.go
+++ b/internal/p2p/sync.go
@@ -836,6 +836,7 @@ func (s *SyncService) AddTrustedPeer(ctx context.Context, peerID peer.ID) error 
 	return nil
 }
 
+
 // SyncWithPeer performs a sync operation with a specific peer
 func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncResult, error) {
 	// Create a context with timeout for the entire operation
@@ -916,8 +917,38 @@ func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncRe
 		result.BytesTransferred += int64(size)
 	}
 
-	// Step 5: Update file manifests
-	result.FileCount = len(remoteManifest.Files) - len(localManifest.Files)
+	// Step 5: Save file manifests for synced files
+	fmt.Println("Saving file manifests...")
+	savedCount := 0
+	for _, remoteFile := range remoteManifest.Files {
+		// Check if this file already exists locally
+		exists := false
+		for _, localFile := range localManifest.Files {
+			if localFile.FilePath == remoteFile.FilePath {
+				exists = true
+				break
+			}
+		}
+		
+		if !exists {
+			// Create a copy of the file manifest to avoid pointer issues
+			fileManifest := remoteFile
+			
+			err := manifest.StoreFileManifest(
+				s.vaultMgr.VaultRoot(),
+				fileManifest.FilePath,
+				&fileManifest,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to save manifest for %s: %v", 
+					fileManifest.FilePath, err)
+			}
+			fmt.Printf("Saved manifest for: %s\n", fileManifest.FilePath)
+			savedCount++
+		}
+	}
+	fmt.Printf("Saved %d file manifests\n", savedCount)
+	result.FileCount = savedCount
 
 	// Step 6: Rebuild references
 	if err := s.vaultMgr.RebuildReferences(); err != nil {


### PR DESCRIPTION
- Add Step 5 in SyncWithPeer to persist new file manifests using manifest.StoreFileManifest
- Ensure manifest YAMLs are written to disk (.sietch/manifests/) for each newly synced file
- Update result.FileCount to reflect number of manifests saved
- Retain pointer safety by copying remoteFile before passing to StoreFileManifest

close issue #48