### PR TITLE
Add sync history #61

### DIFF
--- a/cmd/sync_history.go
+++ b/cmd/sync_history.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+type FileInfo struct {
+    Path string `json:"path"`
+    Size int64  `json:"size"` // in bytes
+}
+
+type SyncHistoryEntry struct {
+	ID                string   	 `json:"id"`
+	Timestamp         string   	 `json:"timestamp"`
+	PeerID            string   	 `json:"peer_id"`
+	PeerName          string   	 `json:"peer_name"`
+	FilesTransferred  int      	 `json:"files_transferred"`
+	ChunksTransferred int      	 `json:"chunks_transferred"`
+	ChunksDeduped     int      	 `json:"chunks_deduplicated"`
+	BytesTransferred  int64    	 `json:"bytes_transferred"`
+	DurationMs        int64    	 `json:"duration_ms"`
+	Status            string   	 `json:"status"`
+	Files             []FileInfo `json:"files"`
+	Error             string     `json:"error,omitempty"`
+}
+
+type SyncHistoryFile struct {
+	Syncs []SyncHistoryEntry `json:"syncs"`
+}
+
+var (
+	historyPeer   string
+	historyFailed bool
+	historyID     string
+	historyExport bool
+)
+
+var syncHistoryCmd = &cobra.Command{
+	Use:   "history",
+	Short: "View sync history",
+	Long:  `View recent sync operations, filter by peer or failed syncs, export to CSV, or view detailed info.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		showSyncHistory()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(syncHistoryCmd)
+	syncHistoryCmd.Flags().StringVar(&historyPeer, "peer", "", "Filter by peer name")
+	syncHistoryCmd.Flags().BoolVar(&historyFailed, "failed", false, "Show only failed syncs")
+	syncHistoryCmd.Flags().StringVar(&historyID, "id", "", "Show detailed info for specific sync ID")
+	syncHistoryCmd.Flags().BoolVar(&historyExport, "export", false, "Export sync history to CSV")
+}
+
+func ensureHistoryFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot find home directory: %v", err)
+	}
+
+	dir := filepath.Join(home, ".sietch")
+	path := filepath.Join(dir, "sync-history.json")
+
+	// Create folder if missing
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return "", fmt.Errorf("failed to create directory: %v", err)
+		}
+	}
+
+	// Create file with empty JSON if missing
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		empty := SyncHistoryFile{Syncs: []SyncHistoryEntry{}}
+		data, _ := json.MarshalIndent(empty, "", "  ")
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			return "", fmt.Errorf("failed to create file: %v", err)
+		}
+	}
+
+	return path, nil
+}
+
+func appendSyncHistory(entry SyncHistoryEntry) error {
+    historyPath, err := ensureHistoryFile()
+    if err != nil {
+        return err
+    }
+
+    file, err := os.OpenFile(historyPath, os.O_RDWR, 0644)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    var history SyncHistoryFile
+    if err := json.NewDecoder(file).Decode(&history); err != nil {
+        return err
+    }
+
+    history.Syncs = append(history.Syncs, entry)
+
+    // reset file to start
+    file.Seek(0, 0)
+    file.Truncate(0)
+
+    encoder := json.NewEncoder(file)
+    encoder.SetIndent("", "  ")
+    return encoder.Encode(history)
+}
+
+func showSyncHistory() {
+	// locate sync-history.json
+	historyPath, err := ensureHistoryFile()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	file, err := os.Open(historyPath)
+	if err != nil {
+		fmt.Println("Cannot open sync history file:", err)
+		return
+	}
+	defer file.Close()
+
+	var history SyncHistoryFile
+	if err := json.NewDecoder(file).Decode(&history); err != nil {
+		fmt.Println("Failed to decode history JSON:", err)
+		return
+	}
+
+	entries := history.Syncs
+
+	// filter by peer
+	if historyPeer != "" {
+		filtered := []SyncHistoryEntry{}
+		for _, e := range entries {
+			if e.PeerName == historyPeer {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	// filter failed only
+	if historyFailed {
+		filtered := []SyncHistoryEntry{}
+		for _, e := range entries {
+			if e.Status == "failed" {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	// show detailed info if --id is provided
+	if historyID != "" {
+		for _, e := range entries {
+			if e.ID == historyID {
+				showDetailedEntry(e)
+				return
+			}
+		}
+		fmt.Println("No sync found with ID:", historyID)
+		return
+	}
+
+	// if --export, write CSV
+	if historyExport {
+		exportCSV(entries)
+		return
+	}
+
+	// sort entries by timestamp (oldest first)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Timestamp < entries[j].Timestamp
+	})
+
+	// otherwise list last 10 entries
+	count := 10
+	if len(entries) < 10 {
+		count = len(entries)
+	}
+	fmt.Println("Last", count, "syncs:")
+	for i := len(entries) - count; i < len(entries); i++ {
+		e := entries[i]
+		status := "✅"
+		if e.Status == "failed" {
+			status = "❌ Failed: " + e.Error
+		} else if e.FilesTransferred == 0 {
+			status = "⚠️ No changes"
+		}
+		fmt.Printf("  %s  %s  %d files  %.2f MB  %s\n",
+			e.Timestamp[:16], e.PeerName, e.FilesTransferred, float64(e.BytesTransferred)/1024/1024, status)
+	}
+}
+
+func showDetailedEntry(e SyncHistoryEntry) {
+	fmt.Printf("Sync ID: %s\nDate: %s\nPeer: %s (%s)\nDirection: bidirectional\n",
+		e.ID, e.Timestamp, e.PeerName, e.PeerID)
+	fmt.Println("Files transferred:")
+	for _, f := range e.Files {
+		fmt.Printf("  - %s (%.2f MB)\n", f.Path, float64(f.Size)/1024/1024)
+	}
+	fmt.Printf("Chunks: %d transferred, %d deduplicated\n", e.ChunksTransferred, e.ChunksDeduped)
+	fmt.Printf("Duration: %.2fs\n", float64(e.DurationMs)/1000)
+	fmt.Printf("Status: %s\n", e.Status)
+	if e.Error != "" {
+		fmt.Println("Error:", e.Error)
+	}
+}
+
+func exportCSV(entries []SyncHistoryEntry) {
+	home, _ := os.UserHomeDir()
+	outPath := filepath.Join(home, ".sietch", "sync-history.csv")
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		fmt.Println("Cannot create CSV file:", err)
+		return
+	}
+	defer outFile.Close()
+
+	writer := csv.NewWriter(outFile)
+	defer writer.Flush()
+
+	writer.Write([]string{"id","timestamp","peer_id","peer_name","files_transferred","chunks_transferred","chunks_deduplicated","bytes_transferred","duration_ms","status","files","error"})
+	for _, e := range entries {
+		writer.Write([]string{
+			e.ID,
+			e.Timestamp,
+			e.PeerID,
+			e.PeerName,
+			strconv.Itoa(e.FilesTransferred),
+			strconv.Itoa(e.ChunksTransferred),
+			strconv.Itoa(e.ChunksDeduped),
+			strconv.FormatInt(e.BytesTransferred, 10),
+			strconv.FormatInt(e.DurationMs, 10),
+			e.Status,
+			fmt.Sprintf("%v", e.Files),
+			e.Error,
+		})
+	}
+	fmt.Println("Exported CSV to", outPath)
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,61 @@
+package history
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// SyncRecord represents a single sync operation
+type SyncRecord struct {
+	ID                 string   `json:"id"`
+	Timestamp          string   `json:"timestamp"`
+	PeerID             string   `json:"peer_id"`
+	PeerName           string   `json:"peer_name"`
+	FilesTransferred   int      `json:"files_transferred"`
+	ChunksTransferred  int      `json:"chunks_transferred"`
+	ChunksDeduplicated int      `json:"chunks_deduplicated"`
+	BytesTransferred   int64    `json:"bytes_transferred"`
+	DurationMs         int64    `json:"duration_ms"`
+	Status             string   `json:"status"`
+	Files              []string `json:"files"`
+	Error              string   `json:"error"`
+}
+
+// History wraps multiple SyncRecords
+type History struct {
+	Syncs []SyncRecord `json:"syncs"`
+}
+
+// AddRecord appends a new record to the JSON file
+func AddRecord(path string, record SyncRecord) error {
+	h, _ := LoadHistory(path)       // ignore errors, create new if missing
+	h.Syncs = append(h.Syncs, record)
+
+	data, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// LoadHistory loads history from a JSON file
+func LoadHistory(path string) (*History, error) {
+	h := &History{}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// If file doesn't exist, return empty history
+		if os.IsNotExist(err) {
+			return h, nil
+		}
+		return nil, err
+	}
+
+	err = json.Unmarshal(data, h)
+	if err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}

--- a/internal/p2p/sync.go
+++ b/internal/p2p/sync.go
@@ -63,6 +63,7 @@ type SyncResult struct {
 	ChunksDeduplicated int
 	BytesTransferred   int64
 	Duration           time.Duration
+	FileListWithSizes           []FileInfo
 }
 
 // NewSyncService creates a new sync service
@@ -849,10 +850,31 @@ func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncRe
 	fmt.Printf("Starting key verification with peer %s...\n", peerID.String())
 	trusted, err := s.VerifyAndExchangeKeys(timeoutCtx, peerID)
 	if err != nil {
+		appendSyncHistory(SyncHistoryEntry{
+			ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			PeerID:    peerID.String(),
+			PeerName:  s.trustedPeers[peerID].Name, // may need safe-check if nil
+			Status:    "failed",
+			Error:     fmt.Sprintf("Key exchange failed: %v", err),
+			Files: result.FileListWithSizes,
+    	})
+
 		return nil, fmt.Errorf("key exchange failed: %w", err)
 	}
 
 	if !trusted {
+		historyEntry := SyncHistoryEntry{
+			ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			PeerID:    peerID.String(),
+			PeerName:  "", // trusted peer not found
+			Status:    "failed",
+			Error:     fmt.Sprintf("peer %s is not trusted", peerID.String()),
+			Files: result.FileListWithSizes,
+		}
+		_ = appendSyncHistory(historyEntry)
+
 		return nil, fmt.Errorf("peer %s is not trusted", peerID.String())
 	}
 	fmt.Printf("Peer %s is trusted, proceeding with sync\n", peerID.String())
@@ -861,13 +883,48 @@ func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncRe
 	fmt.Printf("Retrieving manifest from peer %s...\n", peerID.String())
 	remoteManifest, err := s.getRemoteManifest(timeoutCtx, peerID)
 	if err != nil {
+		historyEntry := SyncHistoryEntry{
+			ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			PeerID:    peerID.String(),
+			PeerName:  s.trustedPeers[peerID].Name,
+			Status:    "failed",
+			Error:     fmt.Sprintf("failed to get remote manifest: %v", err),
+			Files: result.FileListWithSizes,
+		}
+		_ = appendSyncHistory(historyEntry)
+
 		return nil, fmt.Errorf("failed to get remote manifest: %v", err)
 	}
 	fmt.Printf("Retrieved manifest from peer with %d files\n", len(remoteManifest.Files))
 
+	// populate FileListWithSizes for history
+	result.FileListWithSizes = []FileInfo{}
+	for _, f := range remoteManifest.Files {
+		size := int64(0)
+		for _, c := range f.Chunks {
+			size += c.Size
+		}
+		result.FileListWithSizes = append(result.FileListWithSizes, FileInfo{
+			Path: f.FilePath,
+			Size: size,
+		})
+	}
+
 	// Step 2: Get local manifest
 	localManifest, err := s.vaultMgr.GetManifest()
 	if err != nil {
+		historyEntry := SyncHistoryEntry{
+			ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			PeerID:    peerID.String(),
+			PeerName:  s.trustedPeers[peerID].Name,
+			Status:    "failed",
+			Error:     fmt.Sprintf("failed to get local manifest: %v", err),
+			Files: result.FileListWithSizes,
+		}
+		_ = appendSyncHistory(historyEntry)
+
 		return nil, fmt.Errorf("failed to get local manifest: %v", err)
 	}
 
@@ -904,11 +961,34 @@ func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncRe
 		// Pass the encrypted hash directly to fetchChunk
 		chunkData, size, err := s.fetchChunk(timeoutCtx, peerID, chunkHash, encryptedHash)
 		if err != nil {
+			historyEntry := SyncHistoryEntry{
+				ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+				PeerID:    peerID.String(),
+				PeerName:  s.trustedPeers[peerID].Name,
+				Status:    "failed",
+				Error:     fmt.Sprintf("failed to fetch chunk %s: %v", chunkHash, err),
+				Files: result.FileListWithSizes,
+			}
+			_ = appendSyncHistory(historyEntry)
+
 			return nil, fmt.Errorf("failed to fetch chunk %s: %v", chunkHash, err)
 		}
 
 		// Store the chunk with both hashes if needed
 		if err := s.StoreChunk(chunkHash, chunkData, encryptedHash); err != nil {
+
+			historyEntry := SyncHistoryEntry{
+				ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+				PeerID:    peerID.String(),
+				PeerName:  s.trustedPeers[peerID].Name,
+				Status:    "failed",
+				Error:     fmt.Sprintf("failed to store chunk %s: %v", chunkHash, err),
+				Files: result.FileListWithSizes,
+			}
+			_ = appendSyncHistory(historyEntry)
+
 			return nil, fmt.Errorf("failed to store chunk %s: %v", chunkHash, err)
 		}
 
@@ -921,12 +1001,43 @@ func (s *SyncService) SyncWithPeer(ctx context.Context, peerID peer.ID) (*SyncRe
 
 	// Step 6: Rebuild references
 	if err := s.vaultMgr.RebuildReferences(); err != nil {
+
+		historyEntry := SyncHistoryEntry{
+			ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			PeerID:    peerID.String(),
+			PeerName:  s.trustedPeers[peerID].Name,
+			Status:    "failed",
+			Error:     fmt.Sprintf("failed to rebuild references: %v", err),
+			Files: result.FileListWithSizes,
+		}
+		_ = appendSyncHistory(historyEntry)
+
 		return nil, fmt.Errorf("failed to rebuild references: %v", err)
 	}
 
 	result.Duration = time.Since(startTime)
 	fmt.Printf("Sync completed in %v: %d files, %d chunks transferred, %d chunks reused\n",
 		result.Duration, result.FileCount, result.ChunksTransferred, result.ChunksDeduplicated)
+
+	// Record history
+	historyEntry := SyncHistoryEntry{
+		ID:                fmt.Sprintf("%d", time.Now().UnixNano()),
+		Timestamp:         time.Now().UTC().Format(time.RFC3339),
+		PeerID:            peerID.String(),
+		PeerName:          s.trustedPeers[peerID].Name,
+		FilesTransferred:  result.FileCount,
+		ChunksTransferred: result.ChunksTransferred,
+		ChunksDeduped:     result.ChunksDeduplicated,
+		BytesTransferred:  result.BytesTransferred,
+		DurationMs:        result.Duration.Milliseconds(),
+		Status:            "success",
+		Files:             result.FileListWithSizes,
+	}
+
+	if err := appendSyncHistory(historyEntry); err != nil {
+		fmt.Println("Failed to append sync history:", err)
+	}
 
 	return result, nil
 }

--- a/internal/p2p/sync_history.go
+++ b/internal/p2p/sync_history.go
@@ -1,0 +1,149 @@
+package p2p
+
+import (
+    "encoding/json"
+    "os"
+    "path/filepath"
+    "time"
+
+    "github.com/google/uuid"
+)
+
+type SyncRecord struct {
+    ID                 string   `json:"id"`
+    Timestamp          string   `json:"timestamp"` // ISO8601
+    PeerID             string   `json:"peer_id"`
+    PeerName           string   `json:"peer_name"`
+    FilesTransferred   int      `json:"files_transferred"`
+    ChunksTransferred  int      `json:"chunks_transferred"`
+    ChunksDeduplicated int      `json:"chunks_deduplicated"`
+    BytesTransferred   int64    `json:"bytes_transferred"`
+    DurationMS         int64    `json:"duration_ms"`
+    Status             string   `json:"status"` // "success", "failed", "no_changes"
+    Files              []string `json:"files"`
+    Error              string   `json:"error,omitempty"`
+}
+
+type SyncHistory struct {
+    Syncs []SyncRecord `json:"syncs"`
+}
+
+// Returns the path to sync-history.json inside the vault
+func getHistoryFilePath(vaultPath string) string {
+    return filepath.Join(vaultPath, ".sietch", "sync-history.json")
+}
+
+// Load history from disk
+func LoadSyncHistory(vaultPath string) (*SyncHistory, error) {
+    path := getHistoryFilePath(vaultPath)
+    history := &SyncHistory{}
+
+    f, err := os.Open(path)
+    if err != nil {
+        if os.IsNotExist(err) {
+            return history, nil // no history yet
+        }
+        return nil, err
+    }
+    defer f.Close()
+
+    err = json.NewDecoder(f).Decode(history)
+    if err != nil {
+        return nil, err
+    }
+    return history, nil
+}
+
+// Save history to disk
+func SaveSyncHistory(vaultPath string, history *SyncHistory) error {
+    path := getHistoryFilePath(vaultPath)
+
+    f, err := os.Create(path)
+    if err != nil {
+        return err
+    }
+    defer f.Close()
+
+    encoder := json.NewEncoder(f)
+    encoder.SetIndent("", "  ")
+    return encoder.Encode(history)
+}
+
+// Add a new record
+func AddSyncRecord(vaultPath string, record SyncRecord) error {
+    history, err := LoadSyncHistory(vaultPath)
+    if err != nil {
+        return err
+    }
+
+    history.Syncs = append([]SyncRecord{record}, history.Syncs...) // newest first
+
+    return SaveSyncHistory(vaultPath, history)
+}
+
+// Helper to create a new SyncRecord
+func NewSyncRecord(peerID, peerName string, files []string, chunksTransferred, chunksDedup int, bytes int64, duration time.Duration, status string, errMsg string) SyncRecord {
+    return SyncRecord{
+        ID:                 uuid.New().String(),
+        Timestamp:          time.Now().UTC().Format(time.RFC3339),
+        PeerID:             peerID,
+        PeerName:           peerName,
+        FilesTransferred:   len(files),
+        ChunksTransferred:  chunksTransferred,
+        ChunksDeduplicated: chunksDedup,
+        BytesTransferred:   bytes,
+        DurationMS:         int64(duration / time.Millisecond),
+        Status:             status,
+        Files:              files,
+        Error:              errMsg,
+    }
+}
+
+// SyncHistoryEntry is an in-memory detailed log used during sync operations.
+type SyncHistoryEntry struct {
+	ID                string     `json:"id"`
+	Timestamp         string     `json:"timestamp"`
+	PeerID            string     `json:"peer_id"`
+	PeerName          string     `json:"peer_name"`
+	Status            string     `json:"status"`
+	Error             string     `json:"error,omitempty"`
+	FilesTransferred  int        `json:"files_transferred,omitempty"`
+	ChunksTransferred int        `json:"chunks_transferred,omitempty"`
+	ChunksDeduped     int        `json:"chunks_deduped,omitempty"`
+	BytesTransferred  int64      `json:"bytes_transferred,omitempty"`
+	DurationMs        int64      `json:"duration_ms,omitempty"`
+	Files             []FileInfo `json:"files,omitempty"`
+}
+
+// FileInfo stores per-file transfer details for sync logs.
+type FileInfo struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// appendSyncHistory bridges between SyncHistoryEntry (detailed)
+// and SyncRecord (persistent JSON storage)
+func appendSyncHistory(entry SyncHistoryEntry) error {
+	vaultPath := "." // TODO: if available, inject real vault path
+	files := make([]string, len(entry.Files))
+	for i, f := range entry.Files {
+		files[i] = f.Path
+	}
+
+	record := SyncRecord{
+		ID:                 entry.ID,
+		Timestamp:          entry.Timestamp,
+		PeerID:             entry.PeerID,
+		PeerName:           entry.PeerName,
+		FilesTransferred:   entry.FilesTransferred,
+		ChunksTransferred:  entry.ChunksTransferred,
+		ChunksDeduplicated: entry.ChunksDeduped,
+		BytesTransferred:   entry.BytesTransferred,
+		DurationMS:         entry.DurationMs,
+		Status:             entry.Status,
+		Files:              files,
+		Error:              entry.Error,
+	}
+
+	return AddSyncRecord(vaultPath, record)
+}


### PR DESCRIPTION
So, im working on https://github.com/SubstantialCattle5/Sietch/issues/61 and the below is my work so far.

Below are 2 Screenshots, first of vault 1(my_sietch) where its waiting for peer's to connect to it and the second is of vault 2(my_sietch2) where i use vault 1's multiaddress to sync to vault 2. Using this i sync the files and transfer a single file of 160B from 1 vault to the other. Along with this the history is saved at vault 2's .sietch/sync-history.json along with details regarding all the sync commands that have been called.



1-->
<img width="1147" height="708" alt="1" src="https://github.com/user-attachments/assets/81d0a83e-0e17-424f-826b-2aad65b727e2" />


2-->
<img width="1311" height="711" alt="2" src="https://github.com/user-attachments/assets/cabf6942-9110-41e2-a0c7-90f9f4a13260" />


In #61 I've implemented the "sietch sync history" command only, and the other 3 i.e
  sietch sync history --peer vault2 - Filter by peer
  sietch sync history --failed - Show only failed syncs
  sietch sync history --export - Export to CSV

are left for other open source contributors to implement. The base structure of these have also been implemented and shouldnt take longer to implement if someone builds upon my code. 





the below is how the sync-history.json looks like after syncing from one vault to the other using vault1's multiaddress -->
<img width="643" height="460" alt="image" src="https://github.com/user-attachments/assets/128bef5c-b4d9-4ffe-a90b-8ef7df8bb55d" />