### PR TITLE
feat: add directory and symlink support to sietch add command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -23,23 +24,36 @@ import (
 // addCmd represents the add command
 var addCmd = &cobra.Command{
 	Use:   "add <source_path> <destination_path> [source_path2] [destination_path2]...",
-	Short: "Add one or more files to the Sietch vault",
-	Long: `Add multiple files to your Sietch vault.
+	Short: "Add files, directories, or symlinks to the Sietch vault",
+	Long: `Add files, directories, or symlinks to your Sietch vault.
 
 This command adds files from the specified source paths to the destination
-paths in your vault, then processes them according to your vault configuration.
+paths in your vault. It supports regular files, directories (recursively),
+and symbolic links (by copying their contents).
 
 Supports two usage patterns:
 1. Paired arguments: sietch add source1 dest1 source2 dest2 ...
-	  Each source file is stored at its corresponding destination path.
+	  Each source is stored at its corresponding destination path.
 
 2. Single destination: sietch add source1 source2 ... dest
-	  All source files are stored under the same destination directory.
+	  All sources are stored under the same destination directory.
+
+Directory handling:
+- Directories are processed recursively
+- Directory structure is preserved in the destination
+- Hidden files and directories are included
+- Symlinks within directories are followed
+
+Symlink handling:
+- Symlinks to files: the target file content is added
+- Symlinks to directories: all files in the target directory are added recursively
 
 Examples:
 	 sietch add document.txt vault/documents/
 	 sietch add file1.txt dest1/ file2.txt dest2/
-	 sietch add ~/photos/img1.jpg ~/photos/img2.jpg vault/photos/`,
+	 sietch add ~/photos vault/photos/
+	 sietch add ~/link-to-file.txt vault/files/
+	 sietch add ~/photos/img1.jpg ~/docs/ vault/backup/`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Validate argument count (reasonable limit for batch operations)
@@ -113,8 +127,8 @@ Examples:
 				fmt.Printf("Processing: %s\n", pair.Source)
 			}
 
-			// Check if file exists and that it is not a directory or symlink
-			fileInfo, err := fs.VerifyFileAndReturnFileInfo(pair.Source)
+			// Check if path exists (accepts files, directories, and symlinks)
+			pathInfo, err := fs.VerifyPathAndReturnInfo(pair.Source)
 			if err != nil {
 				errorMsg := fmt.Sprintf("✗ %s: %v", filepath.Base(pair.Source), err)
 				fmt.Println(errorMsg)
@@ -122,61 +136,121 @@ Examples:
 				continue
 			}
 
-			// Get file size in human-readable format
-			sizeInBytes := fileInfo.Size()
-			sizeReadable := util.HumanReadableSize(sizeInBytes)
+			// Collect all files to process (handles directories and symlinks)
+			var filesToProcess []string
+			if pathInfo.IsDir() || pathInfo.Mode()&os.ModeSymlink != 0 {
+				// For directories and symlinks, recursively collect all files
+				filesToProcess, err = fs.CollectFilesRecursively(pair.Source)
+				if err != nil {
+					errorMsg := fmt.Sprintf("✗ %s: %v", filepath.Base(pair.Source), err)
+					fmt.Println(errorMsg)
+					failedFiles = append(failedFiles, errorMsg)
+					continue
+				}
 
-			// Display file metadata for confirmation (only for single files or when verbose)
-			verbose, _ := cmd.Flags().GetBool("verbose")
-			if len(filePairs) == 1 || verbose {
-				fmt.Printf("  Size: %s (%d bytes)\n", sizeReadable, sizeInBytes)
-				fmt.Printf("  Modified: %s\n", fileInfo.ModTime().Format(time.RFC3339))
-				if len(tags) > 0 {
-					fmt.Printf("  Tags: %s\n", strings.Join(tags, ", "))
+				if len(filesToProcess) == 0 {
+					fmt.Printf("⚠ %s: directory is empty, skipping\n", filepath.Base(pair.Source))
+					continue
+				}
+
+				fmt.Printf("  Found %d file(s) to add\n", len(filesToProcess))
+			} else {
+				// Regular file
+				filesToProcess = []string{pair.Source}
+			}
+
+			// Process each collected file
+			processedCount := 0
+			for _, sourceFile := range filesToProcess {
+				// Get file info for the actual file
+				fileInfo, err := fs.VerifyFileAndReturnFileInfo(sourceFile)
+				if err != nil {
+					errorMsg := fmt.Sprintf("✗ %s: %v", filepath.Base(sourceFile), err)
+					fmt.Println(errorMsg)
+					failedFiles = append(failedFiles, errorMsg)
+					continue
+				}
+
+				// Get file size in human-readable format
+				sizeInBytes := fileInfo.Size()
+				sizeReadable := util.HumanReadableSize(sizeInBytes)
+
+				// Display file metadata for confirmation (only for single files or when verbose)
+				verbose, _ := cmd.Flags().GetBool("verbose")
+				if len(filePairs) == 1 || verbose {
+					fmt.Printf("    %s: %s (%d bytes)\n", filepath.Base(sourceFile), sizeReadable, sizeInBytes)
+					if verbose {
+						fmt.Printf("    Modified: %s\n", fileInfo.ModTime().Format(time.RFC3339))
+					}
+				}
+
+				// Calculate relative path for destination if processing directory
+				var destPath string
+				if len(filesToProcess) > 1 {
+					// For directories, preserve the structure
+					relPath, err := filepath.Rel(pair.Source, sourceFile)
+					if err != nil {
+						// If we can't get relative path, use just the filename
+						destPath = filepath.Join(pair.Destination, filepath.Base(sourceFile))
+					} else {
+						destPath = filepath.Join(pair.Destination, relPath)
+					}
+				} else {
+					destPath = pair.Destination
+				}
+
+				// Process the file and store chunks
+				var chunkRefs []config.ChunkRef
+				chunkRefs, err = chunk.ChunkFile(sourceFile, chunkSize, vaultRoot, passphrase)
+
+				if err != nil {
+					errorMsg := fmt.Sprintf("✗ %s: chunking failed - %v", filepath.Base(sourceFile), err)
+					fmt.Println(errorMsg)
+					failedFiles = append(failedFiles, errorMsg)
+					continue
+				}
+
+				// Create and store the file manifest
+				fileManifest := &config.FileManifest{
+					FilePath:    filepath.Base(sourceFile),
+					Size:        sizeInBytes,
+					ModTime:     fileInfo.ModTime().Format(time.RFC3339),
+					Chunks:      chunkRefs,
+					Destination: destPath,
+					AddedAt:     time.Now().UTC(),
+					Tags:        tags, // Include tags in the manifest
+				}
+
+				// Save the manifest
+				err = manifest.StoreFileManifest(vaultRoot, filepath.Base(sourceFile), fileManifest)
+				if err != nil {
+					errorMsg := fmt.Sprintf("✗ %s: manifest storage failed - %v", filepath.Base(sourceFile), err)
+					fmt.Println(errorMsg)
+					failedFiles = append(failedFiles, errorMsg)
+					continue
+				}
+
+				// Success message (compact for directories)
+				if len(filesToProcess) > 1 {
+					fmt.Printf("    ✓ %s (%d chunks)\n", filepath.Base(sourceFile), len(chunkRefs))
+				} else if len(filePairs) > 1 {
+					fmt.Printf("✓ %s (%d chunks)\n", filepath.Base(sourceFile), len(chunkRefs))
+				} else {
+					fmt.Printf("✓ File added to vault: %s\n", filepath.Base(sourceFile))
+					fmt.Printf("✓ %d chunks stored in vault\n", len(chunkRefs))
+					fmt.Printf("✓ Manifest written to .sietch/manifests/%s.yaml\n", filepath.Base(sourceFile))
+				}
+
+				processedCount++
+			}
+
+			// Update success count for this pair
+			if processedCount > 0 {
+				successCount += processedCount
+				if len(filesToProcess) > 1 {
+					fmt.Printf("✓ Added %d file(s) from %s\n", processedCount, filepath.Base(pair.Source))
 				}
 			}
-
-			// Process the file and store chunks - using the appropriate chunking function
-			var chunkRefs []config.ChunkRef
-			chunkRefs, err = chunk.ChunkFile(pair.Source, chunkSize, vaultRoot, passphrase)
-
-			if err != nil {
-				errorMsg := fmt.Sprintf("✗ %s: chunking failed - %v", filepath.Base(pair.Source), err)
-				fmt.Println(errorMsg)
-				failedFiles = append(failedFiles, errorMsg)
-				continue
-			}
-
-			// Create and store the file manifest
-			fileManifest := &config.FileManifest{
-				FilePath:    filepath.Base(pair.Source),
-				Size:        sizeInBytes,
-				ModTime:     fileInfo.ModTime().Format(time.RFC3339),
-				Chunks:      chunkRefs,
-				Destination: pair.Destination,
-				AddedAt:     time.Now().UTC(),
-				Tags:        tags, // Include tags in the manifest
-			}
-
-			// Save the manifest
-			err = manifest.StoreFileManifest(vaultRoot, filepath.Base(pair.Source), fileManifest)
-			if err != nil {
-				errorMsg := fmt.Sprintf("✗ %s: manifest storage failed - %v", filepath.Base(pair.Source), err)
-				fmt.Println(errorMsg)
-				failedFiles = append(failedFiles, errorMsg)
-				continue
-			}
-
-			// Success message
-			if len(filePairs) > 1 {
-				fmt.Printf("✓ %s (%d chunks)\n", filepath.Base(pair.Source), len(chunkRefs))
-			} else {
-				fmt.Printf("✓ File added to vault: %s\n", filepath.Base(pair.Source))
-				fmt.Printf("✓ %d chunks stored in vault\n", len(chunkRefs))
-				fmt.Printf("✓ Manifest written to .sietch/manifests/%s.yaml\n", filepath.Base(pair.Source))
-			}
-
-			successCount++
 		}
 
 		// Enhanced summary
@@ -265,6 +339,4 @@ func init() {
 	addCmd.Flags().StringP("passphrase-value", "p", "", "Passphrase for encrypted vault (if required)")
 }
 
-//TODO: Add support for directories and symlinks
-//TODO: Need to check how symlinks will be handled
 //TODO: Interactive mode with real time progress indicators

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -101,15 +101,16 @@ func TestAddCommandUsageText(t *testing.T) {
 }
 
 func TestAddCommandLongDescription(t *testing.T) {
-	// Check that long description contains multiple file support information
+	// Check that long description contains file, directory, and symlink support information
 	longText := addCmd.Long
 
 	expectedPhrases := []string{
-		"multiple files",
 		"Paired arguments",
 		"Single destination",
 		"source1 dest1 source2 dest2",
 		"source1 source2 ... dest",
+		"directories",
+		"symlinks",
 	}
 
 	for _, phrase := range expectedPhrases {
@@ -120,11 +121,12 @@ func TestAddCommandLongDescription(t *testing.T) {
 }
 
 func TestAddCommandShortDescription(t *testing.T) {
-	// Check that short description reflects multiple file support
+	// Check that short description reflects file, directory, and symlink support
 	shortText := addCmd.Short
 
-	if !strings.Contains(shortText, "one or more files") {
-		t.Errorf("Short description should indicate multiple file support, got: %s", shortText)
+	// Should mention either "files" or "directories" or "symlinks"
+	if !strings.Contains(shortText, "files") && !strings.Contains(shortText, "directories") && !strings.Contains(shortText, "symlinks") {
+		t.Errorf("Short description should indicate file, directory, or symlink support, got: %s", shortText)
 	}
 }
 

--- a/internal/fs/helper.go
+++ b/internal/fs/helper.go
@@ -79,6 +79,23 @@ func VerifyFileAndReturnFileInfo(filePath string) (os.FileInfo, error) {
 	return fileInfo, nil
 }
 
+// VerifyPathAndReturnInfo verifies that a path exists and returns its file info
+// Accepts regular files, directories, and symlinks
+func VerifyPathAndReturnInfo(path string) (os.FileInfo, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("path does not exist: %s", path)
+		}
+		if os.IsPermission(err) {
+			return nil, fmt.Errorf("permission denied: %s", path)
+		}
+		return nil, fmt.Errorf("error accessing path: %v", err)
+	}
+
+	return fileInfo, nil
+}
+
 func VerifyFileAndReturnFile(filePath string) (*os.File, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -88,4 +105,87 @@ func VerifyFileAndReturnFile(filePath string) (*os.File, error) {
 		return nil, fmt.Errorf("error opening file: %v", err)
 	}
 	return file, nil
+}
+
+// CollectFilesRecursively recursively collects all regular files from a directory
+// Follows symlinks and adds their target files
+func CollectFilesRecursively(path string) ([]string, error) {
+	var files []string
+
+	// Get file info (follows symlinks by default)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("error accessing %s: %v", path, err)
+	}
+
+	// If it's a regular file, return it directly
+	if fileInfo.Mode().IsRegular() {
+		return []string{path}, nil
+	}
+
+	// If it's a directory, walk through it
+	if fileInfo.IsDir() {
+		err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+			if err != nil {
+				// Check if it's a permission error
+				if os.IsPermission(err) {
+					fmt.Printf("Warning: Permission denied for %s, skipping\n", filePath)
+					return nil // Skip this file but continue walking
+				}
+				return err
+			}
+
+			// Check if it's a symlink
+			if info.Mode()&os.ModeSymlink != 0 {
+				// Resolve symlink
+				target, err := os.Readlink(filePath)
+				if err != nil {
+					fmt.Printf("Warning: Cannot read symlink %s: %v, skipping\n", filePath, err)
+					return nil
+				}
+
+				// Make target path absolute if it's relative
+				if !filepath.IsAbs(target) {
+					target = filepath.Join(filepath.Dir(filePath), target)
+				}
+
+				// Get info about the symlink target
+				targetInfo, err := os.Stat(target)
+				if err != nil {
+					fmt.Printf("Warning: Cannot access symlink target %s -> %s: %v, skipping\n", filePath, target, err)
+					return nil
+				}
+
+				// If target is a regular file, add it
+				if targetInfo.Mode().IsRegular() {
+					files = append(files, target)
+				} else if targetInfo.IsDir() {
+					// If target is a directory, recursively collect files from it
+					dirFiles, err := CollectFilesRecursively(target)
+					if err != nil {
+						fmt.Printf("Warning: Error collecting files from symlinked directory %s: %v, skipping\n", target, err)
+						return nil
+					}
+					files = append(files, dirFiles...)
+				}
+				return nil
+			}
+
+			// Add regular files
+			if info.Mode().IsRegular() {
+				files = append(files, filePath)
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		return files, nil
+	}
+
+	// If it's a symlink (shouldn't happen as os.Stat follows symlinks, but just in case)
+	return nil, fmt.Errorf("unexpected file type for %s", path)
 }


### PR DESCRIPTION
This commit implements support for adding directories and symbolic links to the vault, addressing issue #29.

Changes:
- Added CollectFilesRecursively() function to recursively collect files from directories and follow symlinks
- Added VerifyPathAndReturnInfo() function to verify paths that can be files, directories, or symlinks
- Updated add command to handle directories recursively while preserving directory structure
- Updated add command to follow symlinks and add their target content
- Added proper permission error handling with warning messages
- Updated help text to document new directory and symlink functionality
- Updated tests to reflect new functionality

Directory handling:
- Processes directories recursively
- Preserves directory structure in destination
- Includes hidden files and directories
- Follows symlinks within directories

Symlink handling:
- For symlinks to files: adds the target file content
- For symlinks to directories: recursively adds all files from target

## Testing
- ✅ All existing tests pass
- ✅ Updated test expectations to match new functionality
- ✅ Manually tested with directories, symlinks, and regular files
- ✅ Verified backward compatibility with existing file addition

## Example Usage
```bash
# Add a directory recursively
sietch add ~/photos vault/photos/

# Add a symlink
sietch add ~/link-to-file.txt vault/files/

# Mix files, directories, and symlinks
sietch add ~/file.txt ~/docs/ ~/link vault/backup/

All changes maintain backward compatibility with existing file addition functionality.

Fixes #29