### PR TITLE
fix/Issue-59 Confusing peer status messages while performing peer dis…

### DIFF
--- a/internal/p2p/sync.go
+++ b/internal/p2p/sync.go
@@ -1112,3 +1112,12 @@ func (s *SyncService) StoreChunk(hash string, data []byte, encryptedHash string)
 
 	return nil
 }
+
+// HasPeer returns true if peer is already in trustedPeers map
+func (s *SyncService) HasPeer(id peer.ID) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.trustedPeers[id]
+	return ok
+}


### PR DESCRIPTION
### 🔧 Improve Peer Discovery Trust Messaging

**Summary**
Refined trust-related output in the peer discovery flow to eliminate contradictory or redundant messages. Messages are now **deterministic**, **accurate**, and aligned with the intended UX pattern.

---

#### 🧩 Key Improvements

* **Consistent messaging:**
  Removed cases where a single discovery flow could print both:

  ```
  Peer already in trusted list …
  Peer added to trusted peers list ✓
  ```

  Output now correctly reflects the actual trust state.

* **Updated `handleDiscoveredPeer` in `discovery_util.go`:**
  Always displays:

  ```
  🔐 Key exchange successful
  Fingerprint: <fingerprint>
  ```

  Then conditionally prints:

  * ✅ **New trust:** “Peer added to trusted list”
  * ℹ️ **Existing trust:** “Peer already trusted (verified)”

* **New helper:**
  Added `HasPeer(peer.ID)` in `sync.go` to cleanly check whether a peer is already trusted before printing any messages.
  → Prevents false “added” notifications.

---

#### 🧱 Implementation Notes

* No changes to underlying trust logic — purely UX/logging improvements.
* `HasPeer()` performs a simple lookup in the `trustedPeers` map (no side effects).
* Existing logging inside `AddTrustedPeer()` remains untouched for minimal risk.
* Sets foundation for **future non-interactive / JSON output modes**.

---

#### 💡 Example Output
<img width="1621" height="659" alt="Screenshot 2025-10-04 171501" src="https://github.com/user-attachments/assets/5a6de5fa-6225-44c1-805b-2afa90a8fee2" />
