### PR TITLE
Add automatic garbage collection when GC threshold is exceeded

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -332,6 +332,8 @@ func runInit(cmd *cobra.Command) error {
 		dedupMaxChunkSize,
 		dedupGCThreshold,
 		true, // index enabled
+		// Default automatic GC settings
+		true, "1h", 1000, true, ".sietch/logs/gc.log", 5000, "",
 	)
 
 	// Initialize RSA config if not present

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,17 @@ Copyright © 2025 SubstantialCattle5, nilaysharan.com
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/substantialcattle5/sietch/internal/fs"
+	"github.com/substantialcattle5/sietch/internal/gc"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -24,10 +31,64 @@ encrypted data across machines, even with limited connectivity.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	// Create context that can be cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Setup signal handling for graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start GC manager in background if in a vault
+	var gcCancel context.CancelFunc
+	if shouldStartGC() {
+		gcCtx, gcCancelFunc := context.WithCancel(ctx)
+		gcCancel = gcCancelFunc
+
+		go func() {
+			if err := gc.StartGlobalGC(gcCtx); err != nil {
+				// Log error but don't fail execution
+				fmt.Printf("Warning: Failed to start automatic GC: %v\n", err)
+			}
+		}()
+	}
+
+	// Handle shutdown
+	go func() {
+		sig := <-sigChan
+		fmt.Printf("\nReceived signal %v, shutting down...\n", sig)
+
+		// Cancel GC manager
+		if gcCancel != nil {
+			gcCancel()
+			time.Sleep(100 * time.Millisecond) // Give GC time to stop
+		}
+
+		cancel()
+		os.Exit(0)
+	}()
+
+	// Execute the command
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+// shouldStartGC determines if GC should be started
+func shouldStartGC() bool {
+	// Check if we're in a vault directory
+	vaultRoot, err := fs.FindVaultRoot()
+	if err != nil {
+		return false
+	}
+
+	// Check if vault is initialized
+	if !fs.IsVaultInitialized(vaultRoot) {
+		return false
+	}
+
+	return true
 }
 
 func init() {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -132,6 +132,8 @@ func runScaffold(templateName, name, path string, force bool) error {
 		cfg.DedupMaxSize,
 		cfg.DedupGCThreshold,
 		cfg.DedupIndexEnabled,
+		// Default automatic GC settings
+		true, "1h", 1000, true, ".sietch/logs/gc.log", 5000, "",
 	)
 
 	// Initialize RSA config if not present

--- a/internal/config/vault.go
+++ b/internal/config/vault.go
@@ -92,6 +92,20 @@ type DeduplicationConfig struct {
 	GCThreshold  int    `yaml:"gc_threshold"`   // Unreferenced chunk count before GC suggestion
 	IndexEnabled bool   `yaml:"index_enabled"`  // Enable chunk index for faster lookups
 	// CrossFileDedup bool   `yaml:"cross_file_dedup"` // Enable deduplication across different files
+
+	// Automatic GC settings
+	AutoGC AutoGCConfig `yaml:"auto_gc,omitempty"` // Automatic garbage collection settings
+}
+
+// AutoGCConfig contains settings for automatic garbage collection
+type AutoGCConfig struct {
+	Enabled         bool   `yaml:"enabled"`           // Enable automatic GC
+	CheckInterval   string `yaml:"check_interval"`    // How often to check (e.g., "1h", "30m")
+	AutoGCThreshold int    `yaml:"auto_gc_threshold"` // Threshold for automatic GC (overrides vault default)
+	EnableLogging   bool   `yaml:"enable_logging"`    // Enable GC logging
+	LogFile         string `yaml:"log_file"`          // Log file path
+	AlertThreshold  int    `yaml:"alert_threshold"`   // Alert when unreferenced chunks exceed this
+	AlertWebhook    string `yaml:"alert_webhook"`     // Webhook URL for alerts
 }
 
 // SyncConfig contains synchronization settings
@@ -193,6 +207,8 @@ func BuildVaultConfig(
 		keyConfig,
 		// Default deduplication settings
 		true, "content", "1KB", "64MB", 1000, true,
+		// Default automatic GC settings
+		true, "1h", 1000, true, ".sietch/logs/gc.log", 5000, "",
 	)
 }
 
@@ -207,6 +223,8 @@ func BuildVaultConfigWithDeduplication(
 	// Deduplication parameters
 	enableDedup bool, dedupStrategy, dedupMinSize, dedupMaxSize string,
 	dedupGCThreshold int, dedupIndexEnabled bool,
+	autoGCEnabled bool, autoGCCheckInterval string, autoGCThreshold int,
+	autoGCLogging bool, autoGCLogFile string, autoGCAlertThreshold int, autoGCWebhook string,
 ) VaultConfig {
 	config := VaultConfig{
 		VaultID:       vaultID,
@@ -236,6 +254,15 @@ func BuildVaultConfigWithDeduplication(
 	config.Deduplication.MaxChunkSize = dedupMaxSize
 	config.Deduplication.GCThreshold = dedupGCThreshold
 	config.Deduplication.IndexEnabled = dedupIndexEnabled
+
+	// Set automatic GC configuration
+	config.Deduplication.AutoGC.Enabled = autoGCEnabled
+	config.Deduplication.AutoGC.CheckInterval = autoGCCheckInterval
+	config.Deduplication.AutoGC.AutoGCThreshold = autoGCThreshold
+	config.Deduplication.AutoGC.EnableLogging = autoGCLogging
+	config.Deduplication.AutoGC.LogFile = autoGCLogFile
+	config.Deduplication.AutoGC.AlertThreshold = autoGCAlertThreshold
+	config.Deduplication.AutoGC.AlertWebhook = autoGCWebhook
 
 	// Set sync configuration
 	config.Sync.Mode = syncMode

--- a/internal/gc/manager.go
+++ b/internal/gc/manager.go
@@ -1,0 +1,168 @@
+package gc
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/deduplication"
+	"github.com/substantialcattle5/sietch/internal/fs"
+)
+
+// Manager manages automatic garbage collection for Sietch vaults
+type Manager struct {
+	vaultRoot string
+	monitor   *Monitor
+	config    config.VaultConfig
+	started   bool
+}
+
+// NewManager creates a new GC manager for a vault
+func NewManager(vaultRoot string) (*Manager, error) {
+	// Check if vault is initialized
+	if !fs.IsVaultInitialized(vaultRoot) {
+		return nil, fmt.Errorf("vault not initialized")
+	}
+
+	// Load vault configuration
+	vaultConfig, err := config.LoadVaultConfig(vaultRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load vault configuration: %w", err)
+	}
+
+	return &Manager{
+		vaultRoot: vaultRoot,
+		config:    *vaultConfig,
+		started:   false,
+	}, nil
+}
+
+// Start begins automatic GC monitoring for the vault
+func (m *Manager) Start(ctx context.Context) error {
+	if m.started {
+		return fmt.Errorf("GC manager already started")
+	}
+
+	// Check if automatic GC is enabled
+	if !m.config.Deduplication.AutoGC.Enabled {
+		return fmt.Errorf("automatic GC is disabled in vault configuration")
+	}
+
+	// Parse check interval
+	checkInterval, err := time.ParseDuration(m.config.Deduplication.AutoGC.CheckInterval)
+	if err != nil {
+		return fmt.Errorf("invalid check interval '%s': %w", m.config.Deduplication.AutoGC.CheckInterval, err)
+	}
+
+	// Create monitor configuration
+	monitorConfig := MonitorConfig{
+		Enabled:         m.config.Deduplication.AutoGC.Enabled,
+		CheckInterval:   checkInterval,
+		AutoGCThreshold: m.getEffectiveGCThreshold(),
+		EnableLogging:   m.config.Deduplication.AutoGC.EnableLogging,
+		LogFile:         m.getEffectiveLogFile(),
+		AlertThreshold:  m.config.Deduplication.AutoGC.AlertThreshold,
+		AlertWebhook:    m.config.Deduplication.AutoGC.AlertWebhook,
+	}
+
+	// Create and start monitor
+	monitor, err := NewMonitor(m.vaultRoot, monitorConfig, m.config.Deduplication)
+	if err != nil {
+		return fmt.Errorf("failed to create GC monitor: %w", err)
+	}
+
+	if err := monitor.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start GC monitor: %w", err)
+	}
+
+	m.monitor = monitor
+	m.started = true
+
+	return nil
+}
+
+// Stop halts automatic GC monitoring
+func (m *Manager) Stop() error {
+	if !m.started {
+		return fmt.Errorf("GC manager not started")
+	}
+
+	err := m.monitor.Stop()
+	m.started = false
+	return err
+}
+
+// IsRunning returns whether the GC manager is currently running
+func (m *Manager) IsRunning() bool {
+	return m.started && m.monitor.IsRunning()
+}
+
+// GetStats returns current deduplication statistics
+func (m *Manager) GetStats() (deduplication.DeduplicationStats, error) {
+	if !m.started {
+		return deduplication.DeduplicationStats{}, fmt.Errorf("GC manager not started")
+	}
+	return m.monitor.GetStats(), nil
+}
+
+// getEffectiveGCThreshold returns the effective GC threshold to use
+func (m *Manager) getEffectiveGCThreshold() int {
+	if m.config.Deduplication.AutoGC.AutoGCThreshold > 0 {
+		return m.config.Deduplication.AutoGC.AutoGCThreshold
+	}
+	return m.config.Deduplication.GCThreshold
+}
+
+// getEffectiveLogFile returns the effective log file path
+func (m *Manager) getEffectiveLogFile() string {
+	if m.config.Deduplication.AutoGC.LogFile != "" {
+		// Convert relative path to absolute path within vault
+		if !filepath.IsAbs(m.config.Deduplication.AutoGC.LogFile) {
+			return filepath.Join(m.vaultRoot, m.config.Deduplication.AutoGC.LogFile)
+		}
+		return m.config.Deduplication.AutoGC.LogFile
+	}
+	return filepath.Join(m.vaultRoot, ".sietch", "logs", "gc.log")
+}
+
+// Global variable to hold the active GC manager
+var activeManager *Manager
+
+// StartGlobalGC starts automatic GC for the vault in the current directory
+func StartGlobalGC(ctx context.Context) error {
+	vaultRoot, err := fs.FindVaultRoot()
+	if err != nil {
+		// Not in a vault, silently ignore
+		return nil
+	}
+
+	manager, err := NewManager(vaultRoot)
+	if err != nil {
+		return fmt.Errorf("failed to create GC manager: %w", err)
+	}
+
+	if err := manager.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start GC manager: %w", err)
+	}
+
+	activeManager = manager
+	return nil
+}
+
+// StopGlobalGC stops the global GC manager
+func StopGlobalGC() error {
+	if activeManager == nil {
+		return nil
+	}
+
+	err := activeManager.Stop()
+	activeManager = nil
+	return err
+}
+
+// GetGlobalGCManager returns the active GC manager
+func GetGlobalGCManager() *Manager {
+	return activeManager
+}

--- a/internal/gc/monitor.go
+++ b/internal/gc/monitor.go
@@ -1,0 +1,256 @@
+package gc
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/constants"
+	"github.com/substantialcattle5/sietch/internal/deduplication"
+)
+
+// MonitorConfig contains configuration for the GC monitor
+type MonitorConfig struct {
+	Enabled         bool          `yaml:"enabled"`
+	CheckInterval   time.Duration `yaml:"check_interval"`    // How often to check threshold
+	AutoGCThreshold int           `yaml:"auto_gc_threshold"` // Threshold for automatic GC
+	EnableLogging   bool          `yaml:"enable_logging"`    // Enable GC logging
+	LogFile         string        `yaml:"log_file"`          // Log file path
+	MaxConcurrentGC int           `yaml:"max_concurrent_gc"` // Max concurrent GC operations
+	AlertThreshold  int           `yaml:"alert_threshold"`   // Alert when unreferenced chunks exceed this
+	AlertWebhook    string        `yaml:"alert_webhook"`     // Webhook URL for alerts
+}
+
+// DefaultMonitorConfig returns default configuration for GC monitoring
+func DefaultMonitorConfig() MonitorConfig {
+	return MonitorConfig{
+		Enabled:         true,
+		CheckInterval:   1 * time.Hour, // Check every hour
+		AutoGCThreshold: 1000,          // Default threshold from vault config
+		EnableLogging:   true,
+		LogFile:         ".sietch/logs/gc.log",
+		MaxConcurrentGC: 1,
+		AlertThreshold:  5000,
+		AlertWebhook:    "",
+	}
+}
+
+// Monitor handles automatic garbage collection monitoring
+type Monitor struct {
+	vaultRoot   string
+	config      MonitorConfig
+	dedupConfig config.DeduplicationConfig
+	manager     *deduplication.Manager
+	isRunning   bool
+	stopChan    chan struct{}
+	wg          sync.WaitGroup
+	mutex       sync.Mutex
+	logger      *log.Logger
+}
+
+// NewMonitor creates a new GC monitor
+func NewMonitor(vaultRoot string, monitorConfig MonitorConfig, dedupConfig config.DeduplicationConfig) (*Monitor, error) {
+	// Initialize deduplication manager
+	manager, err := deduplication.NewManager(vaultRoot, dedupConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create deduplication manager: %w", err)
+	}
+
+	monitor := &Monitor{
+		vaultRoot:   vaultRoot,
+		config:      monitorConfig,
+		dedupConfig: dedupConfig,
+		manager:     manager,
+		isRunning:   false,
+		stopChan:    make(chan struct{}),
+	}
+
+	// Set default threshold if not configured
+	if monitorConfig.AutoGCThreshold == 0 {
+		monitorConfig.AutoGCThreshold = dedupConfig.GCThreshold
+	}
+
+	// Setup logging if enabled
+	if monitorConfig.EnableLogging {
+		monitor.setupLogging(monitorConfig.LogFile)
+	}
+
+	return monitor, nil
+}
+
+// Start begins the GC monitoring process
+func (m *Monitor) Start(ctx context.Context) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.isRunning {
+		return fmt.Errorf("GC monitor is already running")
+	}
+
+	if !m.config.Enabled {
+		return fmt.Errorf("GC monitor is disabled")
+	}
+
+	m.isRunning = true
+	m.stopChan = make(chan struct{})
+
+	m.wg.Add(1)
+	go m.monitorLoop(ctx)
+
+	m.log("GC monitor started with check interval: %v", m.config.CheckInterval)
+	return nil
+}
+
+// Stop halts the GC monitoring process
+func (m *Monitor) Stop() error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if !m.isRunning {
+		return fmt.Errorf("GC monitor is not running")
+	}
+
+	close(m.stopChan)
+	m.wg.Wait()
+	m.isRunning = false
+
+	m.log("GC monitor stopped")
+	return nil
+}
+
+// IsRunning returns whether the monitor is currently running
+func (m *Monitor) IsRunning() bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.isRunning
+}
+
+// monitorLoop is the main monitoring loop
+func (m *Monitor) monitorLoop(ctx context.Context) {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.config.CheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			m.log("GC monitor context cancelled")
+			return
+		case <-m.stopChan:
+			m.log("GC monitor stop signal received")
+			return
+		case <-ticker.C:
+			if err := m.checkAndTriggerGC(); err != nil {
+				m.log("Error during GC check: %v", err)
+			}
+		}
+	}
+}
+
+// checkAndTriggerGC checks if GC threshold is exceeded and triggers GC if needed
+func (m *Monitor) checkAndTriggerGC() error {
+	// Get current statistics
+	stats := m.manager.GetStats()
+
+	m.log("GC check: %d unreferenced chunks (threshold: %d)",
+		stats.UnreferencedChunks, m.config.AutoGCThreshold)
+
+	// Check if threshold is exceeded
+	if stats.UnreferencedChunks >= m.config.AutoGCThreshold {
+		m.log("GC threshold exceeded (%d >= %d), triggering automatic GC",
+			stats.UnreferencedChunks, m.config.AutoGCThreshold)
+
+		// Trigger garbage collection
+		if err := m.triggerGC(); err != nil {
+			return fmt.Errorf("automatic GC failed: %w", err)
+		}
+
+		// Check if we should send alert
+		if m.shouldAlert(stats.UnreferencedChunks) {
+			m.sendAlert(stats)
+		}
+	}
+
+	return nil
+}
+
+// triggerGC performs garbage collection
+func (m *Monitor) triggerGC() error {
+	m.log("Starting automatic garbage collection...")
+
+	// Run garbage collection
+	removedChunks, err := m.manager.GarbageCollect()
+	if err != nil {
+		return fmt.Errorf("garbage collection failed: %w", err)
+	}
+
+	// Save the updated index
+	if err := m.manager.Save(); err != nil {
+		return fmt.Errorf("failed to save index after GC: %w", err)
+	}
+
+	m.log("Automatic GC completed: removed %d chunks", removedChunks)
+	return nil
+}
+
+// shouldAlert determines if an alert should be sent
+func (m *Monitor) shouldAlert(unreferencedCount int) bool {
+	return m.config.AlertWebhook != "" && unreferencedCount >= m.config.AlertThreshold
+}
+
+// sendAlert sends an alert via webhook
+func (m *Monitor) sendAlert(stats deduplication.DeduplicationStats) {
+	m.log("Alert: High number of unreferenced chunks detected: %d", stats.UnreferencedChunks)
+
+	if m.config.AlertWebhook != "" {
+		// TODO: Implement HTTP POST to webhook URL
+		// For now, just log the webhook URL
+		m.log("Would send webhook alert to: %s", m.config.AlertWebhook)
+	}
+}
+
+// setupLogging initializes the logger with file output
+func (m *Monitor) setupLogging(logFile string) {
+	// Ensure log directory exists
+	logDir := filepath.Dir(logFile)
+	if err := os.MkdirAll(logDir, constants.StandardDirPerms); err != nil {
+		fmt.Printf("Warning: Failed to create log directory %s: %v\n", logDir, err)
+		m.logger = log.Default()
+		return
+	}
+
+	// Open log file
+	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, constants.StandardFilePerms)
+	if err != nil {
+		fmt.Printf("Warning: Failed to open log file %s: %v\n", logFile, err)
+		m.logger = log.Default()
+		return
+	}
+
+	m.logger = log.New(file, "[GC Monitor] ", log.LstdFlags)
+}
+
+// log logs a message if logging is enabled
+func (m *Monitor) log(format string, args ...interface{}) {
+	if m.config.EnableLogging && m.logger != nil {
+		m.logger.Printf(format, args...)
+	}
+}
+
+// GetStats returns current deduplication statistics
+func (m *Monitor) GetStats() deduplication.DeduplicationStats {
+	return m.manager.GetStats()
+}
+
+// UpdateConfig updates the monitor configuration
+func (m *Monitor) UpdateConfig(config MonitorConfig) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.config = config
+}


### PR DESCRIPTION
**Description**
This PR implements automatic garbage collection (GC) execution for Sietch vaults when the configured GC threshold is exceeded. The feature ensures storage efficiency by automatically cleaning up unused or orphaned chunks without requiring manual intervention.


**Configuration Options:**
```yml
deduplication:
  auto_gc:
    enabled: true              # Enable automatic GC
    check_interval: "1h"       # Check every hour
    auto_gc_threshold: 1000    # Auto-trigger threshold
    enable_logging: true       # Enable GC logging
    log_file: ".sietch/logs/gc.log"
    alert_threshold: 5000      # Alert threshold
    alert_webhook: "https://hooks.example.com/alerts"
```

**New Files**
- `internal/gc/monitor.go` - New automatic GC monitoring service
- `internal/gc/manager.go` - GC manager for vault lifecycle