### PR TITLE
cmd: add --dedup-stats flag to ls; show per-file dedup stats

### DIFF
--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -64,9 +64,16 @@ Examples:
 		long, _ := cmd.Flags().GetBool("long")
 		showTags, _ := cmd.Flags().GetBool("tags")
 		sortBy, _ := cmd.Flags().GetString("sort")
+		showDedup, _ := cmd.Flags().GetBool("dedup-stats")
 
 		// Filter and sort files
 		files := filterAndSortFiles(manifest.Files, filterPath, sortBy)
+
+		// Build chunk -> files index only if dedup stats requested
+		var chunkRefs map[string][]string
+		if showDedup {
+			chunkRefs = buildChunkIndex(manifest.Files)
+		}
 
 		// Display the files
 		if len(files) == 0 {
@@ -79,9 +86,9 @@ Examples:
 		}
 
 		if long {
-			displayLongFormat(files, showTags)
+			displayLongFormat(files, showTags, showDedup, chunkRefs)
 		} else {
-			displayShortFormat(files, showTags)
+			displayShortFormat(files, showTags, showDedup, chunkRefs)
 		}
 
 		return nil
@@ -125,7 +132,8 @@ func filterAndSortFiles(files []config.FileManifest, filterPath, sortBy string) 
 }
 
 // Display files in long format with detailed information
-func displayLongFormat(files []config.FileManifest, showTags bool) {
+// showDedup = whether to include dedup stats; chunkRefs is map[chunkID][]filePaths
+func displayLongFormat(files []config.FileManifest, showTags, showDedup bool, chunkRefs map[string][]string) {
 	// Create a tabwriter for aligned columns
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer w.Flush()
@@ -159,11 +167,28 @@ func displayLongFormat(files []config.FileManifest, showTags bool) {
 				len(file.Chunks),
 				file.Destination+file.FilePath)
 		}
+
+		// Dedup stats (print an indented stats line after the file line)
+		if showDedup && chunkRefs != nil {
+			sharedChunks, savedBytes, sharedWith := computeDedupStatsForFile(file, chunkRefs)
+			// Format saved size
+			savedStr := util.HumanReadableSize(int64(savedBytes))
+			// Format shared_with string with truncation
+			sharedWithStr := formatSharedWith(sharedWith, 10)
+			// Print as indented info (not part of the tabwriter)
+			if len(sharedWith) == 0 {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", "", "", "", "") // ensure tabwriter alignment
+				fmt.Fprintf(w, "    shared_chunks: %d\t saved: %s\n", sharedChunks, savedStr)
+			} else {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", "", "", "", "") // alignment spacer
+				fmt.Fprintf(w, "    shared_chunks: %d\t saved: %s\t shared_with: %s\n", sharedChunks, savedStr, sharedWithStr)
+			}
+		}
 	}
 }
 
 // Display files in short format
-func displayShortFormat(files []config.FileManifest, showTags bool) {
+func displayShortFormat(files []config.FileManifest, showTags, showDedup bool, chunkRefs map[string][]string) {
 	for _, file := range files {
 		path := file.Destination + file.FilePath
 		if showTags && len(file.Tags) > 0 {
@@ -172,7 +197,108 @@ func displayShortFormat(files []config.FileManifest, showTags bool) {
 		} else {
 			fmt.Println(path)
 		}
+
+		// Dedup stats line if requested
+		if showDedup && chunkRefs != nil {
+			sharedChunks, savedBytes, sharedWith := computeDedupStatsForFile(file, chunkRefs)
+			savedStr := util.HumanReadableSize(int64(savedBytes))
+			sharedWithStr := formatSharedWith(sharedWith, 10)
+			if len(sharedWith) == 0 {
+				fmt.Printf("  shared_chunks: %d  saved: %s\n", sharedChunks, savedStr)
+			} else {
+				fmt.Printf("  shared_chunks: %d  saved: %s  shared_with: %s\n", sharedChunks, savedStr, sharedWithStr)
+			}
+		}
 	}
+}
+
+// buildChunkIndex creates a mapping chunkID -> []filePaths using the manifest file list.
+// Uses ChunkRef.Hash as the chunk identifier.
+func buildChunkIndex(files []config.FileManifest) map[string][]string {
+	chunkRefs := make(map[string][]string)
+	for _, f := range files {
+		fp := f.Destination + f.FilePath
+		for _, c := range f.Chunks {
+			// use the Hash field as the chunk identifier
+			chunkID := c.Hash
+			if chunkID == "" {
+				// fallback: if Hash is empty, use EncryptedHash
+				chunkID = c.EncryptedHash
+			}
+			if chunkID == "" {
+				// skip weird entries
+				continue
+			}
+			chunkRefs[chunkID] = append(chunkRefs[chunkID], fp)
+		}
+	}
+	return chunkRefs
+}
+
+// computeDedupStatsForFile calculates dedup stats by consulting chunkRefs map.
+// Uses EncryptedSize if present, otherwise Size, otherwise falls back to default chunk size.
+func computeDedupStatsForFile(file config.FileManifest, chunkRefs map[string][]string) (sharedChunks int, savedBytes int64, sharedWith []string) {
+	// Default chunk size assumption (matches docs): 4 MiB
+	const defaultChunkSize int64 = 4 * 1024 * 1024
+
+	sharedWithSet := make(map[string]struct{})
+	filePath := file.Destination + file.FilePath
+
+	for _, c := range file.Chunks {
+		chunkID := c.Hash
+		if chunkID == "" {
+			chunkID = c.EncryptedHash
+		}
+		if chunkID == "" {
+			continue
+		}
+
+		refs, ok := chunkRefs[chunkID]
+		if !ok {
+			continue
+		}
+		if len(refs) > 1 {
+			sharedChunks++
+
+			// Prefer encrypted size if available (actual stored size), fallback to plaintext size
+			var chunkSize int64
+			if c.EncryptedSize > 0 {
+				chunkSize = c.EncryptedSize
+			} else if c.Size > 0 {
+				chunkSize = c.Size
+			} else {
+				chunkSize = defaultChunkSize
+			}
+			savedBytes += chunkSize
+
+			for _, other := range refs {
+				if other == filePath {
+					continue
+				}
+				sharedWithSet[other] = struct{}{}
+			}
+		}
+	}
+
+	sharedWith = make([]string, 0, len(sharedWithSet))
+	for s := range sharedWithSet {
+		sharedWith = append(sharedWith, s)
+	}
+	// sort for deterministic output
+	sort.Strings(sharedWith)
+	return
+}
+
+// formatSharedWith joins sharedWith and truncates after limit entries, showing (+N more)
+func formatSharedWith(list []string, limit int) string {
+	if len(list) == 0 {
+		return ""
+	}
+	if len(list) <= limit {
+		return strings.Join(list, ", ")
+	}
+	visible := list[:limit]
+	return fmt.Sprintf("%s (+%d more)", strings.Join(visible, ", "), len(list)-limit)
 }
 
 func init() {
@@ -182,4 +308,7 @@ func init() {
 	lsCmd.Flags().BoolP("long", "l", false, "Use long listing format")
 	lsCmd.Flags().BoolP("tags", "t", false, "Show file tags")
 	lsCmd.Flags().StringP("sort", "s", "path", "Sort by: name, size, time, path")
+
+	// New dedup-stats flag
+	lsCmd.Flags().BoolP("dedup-stats", "d", false, "Show per-file deduplication statistics")
 }


### PR DESCRIPTION
This PR adds a `--dedup-stats` (`-d`) flag to `sietch ls`. When enabled, `ls` will:

- Show number of shared chunks per file (`shared_chunks`).
- Show estimated bytes avoided per file due to dedup (`saved`) using per-chunk EncryptedSize (fallbacks to Size, then 4MiB default).
- List other files that share those chunks (`shared_with`) — truncated to first 10 entries.

Notes:
- The saved bytes reflect how much duplicate data the file avoided storing (per-file view).
- For global reclaimed space metrics we could show `(refs-1)*chunkSize` aggregated per chunk; can be implemented in a follow-up PR.
- Includes unit test for `computeDedupStatsForFile`.

<img width="596" height="298" alt="Screenshot 2025-10-05 at 9 03 25 PM" src="https://github.com/user-attachments/assets/100c5498-654f-4b41-9b97-1f448fd91364" />

- The above image shows the implementation of the cmd   `sietch ls --dedup-stats`

<img width="888" height="254" alt="image" src="https://github.com/user-attachments/assets/1ef59e43-7b4f-42e2-b27b-a4a699ad6b48" />

- The above image shows the implementation of the cmd   `sietch ls -l -d`

Fixes: #96 