### PR TITLE
Add `manifest` command with `--file`, `--json` and `--verify`

### DIFF
--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -1,0 +1,288 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/substantialcattle5/sietch/internal/config"
+	"github.com/substantialcattle5/sietch/internal/fs"
+	manifestbuilder "github.com/substantialcattle5/sietch/internal/manifest"
+)
+
+type manifestSummaryOutput struct {
+	VaultName      string `json:"vault_name"`
+	VaultPath      string `json:"vault_path"`
+	EncryptionType string `json:"encryption_type"`
+	KeyPath        string `json:"key_path,omitempty"`
+	ChunkSize      string `json:"chunk_size"`
+	ManifestCount  int    `json:"manifest_count"`
+}
+
+type fileManifestOutput struct {
+	ManifestID   string            `json:"manifest_id"`
+	File         string            `json:"file"`
+	Destination  string            `json:"destination"`
+	FullPath     string            `json:"full_path"`
+	ChunkCount   int               `json:"chunk_count"`
+	ChunkRefs    []config.ChunkRef `json:"chunk_refs"`
+	Tags         []string          `json:"tags,omitempty"`
+	ModifiedAt   string            `json:"modified_at"`
+	AddedAt      string            `json:"added_at"`
+	LastSynced   string            `json:"last_synced,omitempty"`
+	LastVerified string            `json:"last_verified,omitempty"`
+}
+
+type verifyOutput struct {
+	Passed   bool     `json:"passed"`
+	Failures []string `json:"failures"`
+}
+
+var manifestCmd = &cobra.Command{
+	Use:   "manifest",
+	Short: "Inspect vault and file manifests",
+	Long: `Inspect vault metadata and file manifest entries.
+
+Examples:
+  sietch manifest
+  sietch manifest --file docs/report.pdf
+  sietch manifest --file report.pdf --json
+  sietch manifest --verify`,
+	RunE: runManifestCommand,
+}
+
+func runManifestCommand(cmd *cobra.Command, _ []string) error {
+	fileArg, _ := cmd.Flags().GetString("file")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	verify, _ := cmd.Flags().GetBool("verify")
+
+	vaultRoot, err := fs.FindVaultRoot()
+	if err != nil {
+		return fmt.Errorf("not inside a vault: %v", err)
+	}
+
+	if verify {
+		result := verifyVaultManifests(vaultRoot)
+		if jsonOutput {
+			if err := writeJSON(cmd, result); err != nil {
+				return err
+			}
+			if !result.Passed {
+				return errors.New("manifest verification failed")
+			}
+			return nil
+		}
+		for _, failure := range result.Failures {
+			fmt.Fprintf(cmd.OutOrStdout(), "FAIL: %s\n", failure)
+		}
+		if result.Passed {
+			fmt.Fprintln(cmd.OutOrStdout(), "Manifest verification passed")
+			return nil
+		}
+		return errors.New("manifest verification failed")
+	}
+
+	if fileArg != "" {
+		manifestID, mf, err := resolveFileManifest(vaultRoot, fileArg)
+		if err != nil {
+			return err
+		}
+		output := buildFileManifestOutput(manifestID, mf)
+		if jsonOutput {
+			return writeJSON(cmd, output)
+		}
+		printFileManifestSummary(cmd, output)
+		return nil
+	}
+
+	summary, err := buildManifestSummary(vaultRoot)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(cmd, summary)
+	}
+	printManifestSummary(cmd, summary)
+	return nil
+}
+
+func buildManifestSummary(vaultRoot string) (manifestSummaryOutput, error) {
+	vaultCfg, err := manifestbuilder.LoadVaultConfig(vaultRoot)
+	if err != nil {
+		return manifestSummaryOutput{}, fmt.Errorf("failed to load vault metadata: %w", err)
+	}
+
+	manifestIDs, err := manifestbuilder.ListFileManifests(vaultRoot)
+	if err != nil {
+		return manifestSummaryOutput{}, fmt.Errorf("failed to list file manifests: %w", err)
+	}
+
+	return manifestSummaryOutput{
+		VaultName:      vaultCfg.Name,
+		VaultPath:      vaultRoot,
+		EncryptionType: vaultCfg.Encryption.Type,
+		KeyPath:        vaultCfg.Encryption.KeyPath,
+		ChunkSize:      vaultCfg.Chunking.ChunkSize,
+		ManifestCount:  len(manifestIDs),
+	}, nil
+}
+
+func resolveFileManifest(vaultRoot, fileArg string) (string, *config.FileManifest, error) {
+	manifestIDs, err := manifestbuilder.ListFileManifests(vaultRoot)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to list file manifests: %w", err)
+	}
+	if len(manifestIDs) == 0 {
+		return "", nil, fmt.Errorf("no files found in vault")
+	}
+
+	sort.Strings(manifestIDs)
+	for _, id := range manifestIDs {
+		if id == fileArg {
+			mf, loadErr := manifestbuilder.LoadFileManifest(vaultRoot, id)
+			if loadErr != nil {
+				return "", nil, fmt.Errorf("failed to load manifest '%s': %w", id, loadErr)
+			}
+			return id, mf, nil
+		}
+	}
+
+	targetBase := filepath.Base(fileArg)
+	var suggestions []string
+	for _, id := range manifestIDs {
+		mf, loadErr := manifestbuilder.LoadFileManifest(vaultRoot, id)
+		if loadErr != nil {
+			continue
+		}
+		fullPath := mf.Destination + mf.FilePath
+		if fullPath == fileArg || mf.FilePath == fileArg || filepath.Base(mf.FilePath) == fileArg || filepath.Base(fullPath) == fileArg {
+			return id, mf, nil
+		}
+		if filepath.Base(fullPath) == targetBase {
+			suggestions = append(suggestions, fullPath)
+		}
+	}
+
+	if len(suggestions) > 0 {
+		return "", nil, fmt.Errorf("no file found matching '%s'. Did you mean one of: %v", fileArg, suggestions)
+	}
+
+	return "", nil, fmt.Errorf("no file found matching '%s'. Use 'sietch ls' to see available files", fileArg)
+}
+
+func buildFileManifestOutput(manifestID string, mf *config.FileManifest) fileManifestOutput {
+	out := fileManifestOutput{
+		ManifestID:  manifestID,
+		File:        mf.FilePath,
+		Destination: mf.Destination,
+		FullPath:    mf.Destination + mf.FilePath,
+		ChunkCount:  len(mf.Chunks),
+		ChunkRefs:   mf.Chunks,
+		Tags:        mf.Tags,
+		ModifiedAt:  mf.ModTime,
+		AddedAt:     mf.AddedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if !mf.LastSynced.IsZero() {
+		out.LastSynced = mf.LastSynced.Format("2006-01-02T15:04:05Z07:00")
+	}
+	if !mf.LastVerified.IsZero() {
+		out.LastVerified = mf.LastVerified.Format("2006-01-02T15:04:05Z07:00")
+	}
+	return out
+}
+
+func verifyVaultManifests(vaultRoot string) verifyOutput {
+	failures := make([]string, 0)
+
+	manifestIDs, err := manifestbuilder.ListFileManifests(vaultRoot)
+	if err != nil {
+		failures = append(failures, fmt.Sprintf("unable to list manifests: %v", err))
+		return verifyOutput{Passed: false, Failures: failures}
+	}
+
+	seenIDs := make(map[string]bool)
+	seenFullPaths := make(map[string]string)
+	for _, id := range manifestIDs {
+		if seenIDs[id] {
+			failures = append(failures, fmt.Sprintf("duplicate manifest ID: %s", id))
+			continue
+		}
+		seenIDs[id] = true
+
+		mf, loadErr := manifestbuilder.LoadFileManifest(vaultRoot, id)
+		if loadErr != nil {
+			failures = append(failures, fmt.Sprintf("missing or unreadable manifest '%s': %v", id, loadErr))
+			continue
+		}
+
+		fullPath := mf.Destination + mf.FilePath
+		if priorID, exists := seenFullPaths[fullPath]; exists {
+			failures = append(failures, fmt.Sprintf("duplicate manifest ID for file '%s': %s and %s", fullPath, priorID, id))
+		} else {
+			seenFullPaths[fullPath] = id
+		}
+
+		if len(mf.Chunks) == 0 {
+			failures = append(failures, fmt.Sprintf("zero-chunk manifest entry: %s", id))
+		}
+	}
+
+	manifestsDir := filepath.Join(vaultRoot, ".sietch", "manifests")
+	for _, id := range manifestIDs {
+		manifestPath := filepath.Join(manifestsDir, id+".yaml")
+		if _, statErr := os.Stat(manifestPath); statErr != nil {
+			failures = append(failures, fmt.Sprintf("missing manifest file for ID '%s'", id))
+		}
+	}
+
+	return verifyOutput{Passed: len(failures) == 0, Failures: failures}
+}
+
+func printManifestSummary(cmd *cobra.Command, summary manifestSummaryOutput) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Vault Name: %s\n", summary.VaultName)
+	fmt.Fprintf(cmd.OutOrStdout(), "Vault Path: %s\n", summary.VaultPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Encryption: %s\n", summary.EncryptionType)
+	if summary.KeyPath != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Key Path: %s\n", summary.KeyPath)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Chunk Size: %s\n", summary.ChunkSize)
+	fmt.Fprintf(cmd.OutOrStdout(), "Manifest Count: %d\n", summary.ManifestCount)
+}
+
+func printFileManifestSummary(cmd *cobra.Command, output fileManifestOutput) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Manifest ID: %s\n", output.ManifestID)
+	fmt.Fprintf(cmd.OutOrStdout(), "Destination: %s\n", output.Destination)
+	fmt.Fprintf(cmd.OutOrStdout(), "File: %s\n", output.File)
+	fmt.Fprintf(cmd.OutOrStdout(), "Full Path: %s\n", output.FullPath)
+	fmt.Fprintf(cmd.OutOrStdout(), "Chunks: %d\n", output.ChunkCount)
+	if len(output.Tags) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "Tags: %s\n", strings.Join(output.Tags, ", "))
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Modified: %s\n", output.ModifiedAt)
+	fmt.Fprintf(cmd.OutOrStdout(), "Added: %s\n", output.AddedAt)
+	if output.LastSynced != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Last Synced: %s\n", output.LastSynced)
+	}
+	if output.LastVerified != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "Last Verified: %s\n", output.LastVerified)
+	}
+}
+
+func writeJSON(cmd *cobra.Command, payload any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(payload)
+}
+
+func init() {
+	rootCmd.AddCommand(manifestCmd)
+	manifestCmd.Flags().String("file", "", "File path, file name, or manifest ID to inspect")
+	manifestCmd.Flags().Bool("json", false, "Output machine-readable JSON")
+	manifestCmd.Flags().Bool("verify", false, "Run manifest consistency checks")
+}

--- a/cmd/manifest_test.go
+++ b/cmd/manifest_test.go
@@ -1,0 +1,243 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestManifestSummaryMode(t *testing.T) {
+	vaultRoot := createManifestTestVault(t)
+	writeManifestFixture(t, vaultRoot, "docs.report.txt", `file: report.txt
+size: 42
+mtime: "2025-01-02T03:04:05Z"
+destination: docs/
+chunks:
+  - hash: chunk-1
+    size: 42
+    index: 0
+tags: ["docs"]
+added_at: "2025-01-02T03:04:05Z"
+`)
+
+	output, err := runManifestForTest(t, vaultRoot, map[string]string{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(output, "Vault Name: Test Vault") {
+		t.Fatalf("expected vault name in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Manifest Count: 1") {
+		t.Fatalf("expected manifest count in output, got: %s", output)
+	}
+}
+
+func TestManifestFileModeWithJSON(t *testing.T) {
+	vaultRoot := createManifestTestVault(t)
+	writeManifestFixture(t, vaultRoot, "docs.report.txt", `file: report.txt
+size: 42
+mtime: "2025-01-02T03:04:05Z"
+destination: docs/
+chunks:
+  - hash: chunk-1
+    size: 42
+    index: 0
+tags: ["docs", "important"]
+added_at: "2025-01-02T03:04:05Z"
+last_synced: "2025-01-03T03:04:05Z"
+last_verified: "2025-01-04T03:04:05Z"
+`)
+
+	output, err := runManifestForTest(t, vaultRoot, map[string]string{"file": "report.txt", "json": "true"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var payload map[string]any
+	if unmarshalErr := json.Unmarshal([]byte(output), &payload); unmarshalErr != nil {
+		t.Fatalf("expected valid json, got error: %v and output: %s", unmarshalErr, output)
+	}
+
+	stableFields := []string{"manifest_id", "file", "destination", "full_path", "chunk_count", "chunk_refs", "modified_at", "added_at"}
+	for _, field := range stableFields {
+		if _, ok := payload[field]; !ok {
+			t.Fatalf("expected field %q in json payload: %v", field, payload)
+		}
+	}
+
+	if payload["full_path"] != "docs/report.txt" {
+		t.Fatalf("expected full_path docs/report.txt, got %#v", payload["full_path"])
+	}
+}
+
+func TestManifestSummaryJSONStableFields(t *testing.T) {
+	vaultRoot := createManifestTestVault(t)
+	writeManifestFixture(t, vaultRoot, "docs.report.txt", `file: report.txt
+size: 42
+mtime: "2025-01-02T03:04:05Z"
+destination: docs/
+chunks:
+  - hash: chunk-1
+    size: 42
+    index: 0
+added_at: "2025-01-02T03:04:05Z"
+`)
+
+	output, err := runManifestForTest(t, vaultRoot, map[string]string{"json": "true"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var payload map[string]any
+	if unmarshalErr := json.Unmarshal([]byte(output), &payload); unmarshalErr != nil {
+		t.Fatalf("expected valid json, got error: %v and output: %s", unmarshalErr, output)
+	}
+
+	stableFields := []string{"vault_name", "vault_path", "encryption_type", "chunk_size", "manifest_count"}
+	for _, field := range stableFields {
+		if _, ok := payload[field]; !ok {
+			t.Fatalf("expected field %q in json payload: %v", field, payload)
+		}
+	}
+}
+
+func TestManifestVerifySuccessAndFailurePaths(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		vaultRoot := createManifestTestVault(t)
+		writeManifestFixture(t, vaultRoot, "docs.report.txt", `file: report.txt
+size: 42
+mtime: "2025-01-02T03:04:05Z"
+destination: docs/
+chunks:
+  - hash: chunk-1
+    size: 42
+    index: 0
+added_at: "2025-01-02T03:04:05Z"
+`)
+
+		_, err := runManifestForTest(t, vaultRoot, map[string]string{"verify": "true"})
+		if err != nil {
+			t.Fatalf("expected verify success, got error: %v", err)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		vaultRoot := createManifestTestVault(t)
+		writeManifestFixture(t, vaultRoot, "docs.report.txt", `file: report.txt
+size: 42
+mtime: "2025-01-02T03:04:05Z"
+destination: docs/
+chunks: []
+added_at: "2025-01-02T03:04:05Z"
+`)
+		writeManifestFixture(t, vaultRoot, "docs.report-copy.txt", `file: report.txt
+size: 42
+mtime: "2025-01-02T03:04:05Z"
+destination: docs/
+chunks:
+  - hash: chunk-2
+    size: 42
+    index: 0
+added_at: "2025-01-02T03:04:05Z"
+`)
+
+		output, err := runManifestForTest(t, vaultRoot, map[string]string{"verify": "true", "json": "true"})
+		if err == nil {
+			t.Fatalf("expected verify failure to return error")
+		}
+
+		var payload map[string]any
+		if unmarshalErr := json.Unmarshal([]byte(output), &payload); unmarshalErr != nil {
+			t.Fatalf("expected valid json, got error: %v and output: %s", unmarshalErr, output)
+		}
+		if payload["passed"] != false {
+			t.Fatalf("expected passed=false, got: %#v", payload["passed"])
+		}
+	})
+}
+
+func createManifestTestVault(t *testing.T) string {
+	t.Helper()
+
+	vaultRoot := t.TempDir()
+	manifestsDir := filepath.Join(vaultRoot, ".sietch", "manifests")
+	if err := os.MkdirAll(manifestsDir, 0o755); err != nil {
+		t.Fatalf("failed to create manifests directory: %v", err)
+	}
+
+	vaultYAML := `name: Test Vault
+vault_id: test-vault-id
+created_at: 2025-01-01T00:00:00Z
+schema_version: 1
+encryption:
+  type: aes
+  key_path: .sietch/keys/master.key
+  passphrase_protected: false
+chunking:
+  strategy: fixed
+  chunk_size: 4MB
+  hash_algorithm: sha256
+compression: gzip
+deduplication:
+  enabled: true
+  strategy: content
+  min_chunk_size: 1KB
+  max_chunk_size: 64MB
+  gc_threshold: 1000
+  index_enabled: true
+sync:
+  mode: local
+  enabled: false
+metadata:
+  author: tester
+  tags: []
+`
+
+	if err := os.WriteFile(filepath.Join(vaultRoot, "vault.yaml"), []byte(vaultYAML), 0o644); err != nil {
+		t.Fatalf("failed to write vault.yaml: %v", err)
+	}
+
+	return vaultRoot
+}
+
+func writeManifestFixture(t *testing.T, vaultRoot, id, content string) {
+	t.Helper()
+	path := filepath.Join(vaultRoot, ".sietch", "manifests", id+".yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write manifest fixture %s: %v", id, err)
+	}
+}
+
+func runManifestForTest(t *testing.T, vaultRoot string, flags map[string]string) (string, error) {
+	t.Helper()
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if chdirErr := os.Chdir(vaultRoot); chdirErr != nil {
+		t.Fatalf("failed to chdir to vault root: %v", chdirErr)
+	}
+	defer os.Chdir(originalDir)
+
+	cmd := &cobra.Command{}
+	buffer := &bytes.Buffer{}
+	cmd.SetOut(buffer)
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().Bool("verify", false, "")
+
+	for name, value := range flags {
+		if setErr := cmd.Flags().Set(name, value); setErr != nil {
+			t.Fatalf("failed to set flag %s=%s: %v", name, value, setErr)
+		}
+	}
+
+	runErr := runManifestCommand(cmd, nil)
+	return strings.TrimSpace(buffer.String()), runErr
+}


### PR DESCRIPTION
### Motivation

- Provide a dedicated CLI for inspecting vault-level metadata and individual file manifests to aid debugging and scripting. 
- Offer machine-readable output for automation and a lightweight verification mode to detect manifest inconsistencies early.

### Description

- Added a new Cobra command in `cmd/manifest.go` registered via `rootCmd.AddCommand(manifestCmd)` that implements `sietch manifest` with `--file`, `--json`, and `--verify` flags. 
- Reused existing manifest helpers from `internal/manifest/builder.go` (`LoadVaultConfig`, `ListFileManifests`, `LoadFileManifest`) to produce vault summary and file manifest views and to implement verification checks. 
- Implemented file resolution behavior consistent with existing commands (match by manifest ID, full path `Destination+FilePath`, `FilePath`, or basename) and stable snake_case JSON field names for scripting. 
- Implemented lightweight verification to detect missing/unreadable manifest files, duplicate manifest IDs (both duplicate filename IDs and duplicate logical file entries), and zero-chunk manifests, returning non-zero on failures and emitting JSON when requested.

### Testing

- Added `cmd/manifest_test.go` which creates temporary vault fixtures (`vault.yaml` + `.sietch/manifests/*.yaml`) and covers summary mode, `--file` JSON output, summary JSON field stability, and `--verify` success/failure paths. 
- Ran formatting and focused unit tests with `gofmt` and `go test ./cmd -run TestManifest -v`, and the manifest-focused tests passed locally. 
- Note: repository pre-commit linting (`golangci-lint`) failed in this environment due to a Go toolchain/version mismatch, which is unrelated to the command logic and does not affect the unit test results above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b297b47ccc83328c417882e1edcdf2)